### PR TITLE
Extended filters in WooCommerce_PDF_Invoices_Export::get_order_items()

### DIFF
--- a/includes/class-wcpdf-export.php
+++ b/includes/class-wcpdf-export.php
@@ -727,11 +727,11 @@ if ( ! class_exists( 'WooCommerce_PDF_Invoices_Export' ) ) {
 					
 					}
 
-					$data_list[] = apply_filters( 'wpo_wcpdf_order_item_data', $data );
+					$data_list[] = apply_filters( 'wpo_wcpdf_order_item_data', $data, $this->order );
 				}
 			}
 
-			return apply_filters( 'wpo_wcpdf_order_items_data', $data_list );
+			return apply_filters( 'wpo_wcpdf_order_items_data', $data_list, $this->order );
 		}
 		
 		/**


### PR DESCRIPTION
Added `order` argument to filters `wpo_wcpdf_order_item_data` and `wpo_wcpdf_order_items_data`. Having the order is necessary to put the item information in context.
