### PR TITLE
add extra order parameter to filter wpo_wcpdf_attach_documents

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -118,7 +118,7 @@ class Main {
 		foreach ($documents as $document) {
 			$attach_documents[ $document->get_type() ] = $document->get_attach_to_email_ids();
 		}
-		$attach_documents = apply_filters('wpo_wcpdf_attach_documents', $attach_documents );
+		$attach_documents = apply_filters('wpo_wcpdf_attach_documents', $attach_documents, $order );
 
 		$document_types = array();
 		foreach ($attach_documents as $document_type => $attach_to_email_ids ) {


### PR DESCRIPTION
Hello!
I am calling the `wpo_wcpdf_attach_documents` filter but I need `$order` information in the callback.
This seems a fairly straigthforwards improvement, unless I am making some horrible mistake!
Thanks,
Guido