### PR TITLE
FIX Order_Document::__construct undefined variable

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -93,7 +93,7 @@ abstract class Order_Document {
 	public function __construct( $order = 0 ) {
 		if ( is_numeric( $order ) && $order > 0 ) {
 			$this->order_id = $order;
-			$this->order = WCX::get_order( $order_id );
+			$this->order = WCX::get_order( $this->order_id );
 		} elseif ( $order instanceof \WC_Order || is_subclass_of( $order, '\WC_Abstract_Order') ) {
 			$this->order_id = WCX_Order::get_id( $order );
 			$this->order = $order;


### PR DESCRIPTION
when passing type int to __construct $order_id variable is undefined