### PR TITLE
Remove blank space in PDF actions buttons alignment (#103)

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -194,11 +194,9 @@ class Admin {
 		$listing_actions = apply_filters( 'wpo_wcpdf_listing_actions', $listing_actions, $order );			
 
 		foreach ($listing_actions as $action => $data) {
-			?>
-			<a href="<?php echo $data['url']; ?>" class="button tips wpo_wcpdf <?php echo $data['exists'] == true ? "exists " . $action : $action; ?>" target="_blank" alt="<?php echo $data['alt']; ?>" data-tip="<?php echo $data['alt']; ?>">
+			?><a href="<?php echo $data['url']; ?>" class="button tips wpo_wcpdf <?php echo $data['exists'] == true ? "exists " . $action : $action; ?>" target="_blank" alt="<?php echo $data['alt']; ?>" data-tip="<?php echo $data['alt']; ?>">
 				<img src="<?php echo $data['img']; ?>" alt="<?php echo $data['alt']; ?>" width="16">
-			</a>
-			<?php
+			</a><?php
 		}
 	}
 	


### PR DESCRIPTION
Fixes issue #103, removing a blank space that was present in the code.

Admin view after change: 
![bild](https://user-images.githubusercontent.com/15849048/96686430-d1b46680-137e-11eb-994b-3f3ec897fcdf.png)

Tested with Plugin version 2.6.1 (not latest, but recent build) on:
- MacOS
-- Firefox 81.0.2 (64-bit) (latest version, MacOS)
-- Chrome Version 86.0.4240.80 (latest version, MacOS)

Wordpress version 5.5.1.

//Would be very happy if you would consider this pull request, as this is my first public pull request. Please give me any feedback if changes are required.