### PR TITLE
Fix invoice notes

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -489,7 +489,7 @@ class Admin {
 						</div>
 						<!-- Read only -->
 						<div class="read-only">
-							<p><?= ( $data['notes']['value'] == strip_tags( $data['notes']['value'] ) ) ? nl2br( $data['notes']['value'] ) : $data['notes']['value'] ; ?></p>
+							<p><?= ( $data['notes']['value'] == strip_tags( $data['notes']['value'] ) ) ? nl2br( $data['notes']['value'] ) : $data['notes']['value']; ?></p>
 						</div>
 						<!-- Editable -->
 						<div class="editable">

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -892,9 +892,8 @@ class Admin {
 				),
 				'b'		=> array(),
 			);
-			// sanitize
-			$notes = sanitize_textarea_field( wp_kses( $form_data['_wcpdf_'.$document_slug.'_notes'], $allowed_html ) );
-			$data['notes'] = nl2br( $notes );
+			
+			$data['notes'] = wp_kses( $form_data['_wcpdf_'.$document_slug.'_notes'], $allowed_html );
 		}
 
 		return $data;

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -489,7 +489,7 @@ class Admin {
 						</div>
 						<!-- Read only -->
 						<div class="read-only">
-							<p><?= $data['notes']['value']; ?></p>
+							<p><?= ( $data['notes']['value'] == strip_tags( $data['notes']['value'] ) ) ? nl2br( $data['notes']['value'] ) : $data['notes']['value'] ; ?></p>
 						</div>
 						<!-- Editable -->
 						<div class="editable">

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -571,6 +571,7 @@ class Admin {
 
 			$order = WCX::get_order( $post_id );
 			if ( $invoice = wcpdf_get_invoice( $order ) ) {
+				$_POST = stripslashes_deep( $_POST );
 				$document_data = $this->process_order_document_form_data( $_POST, $invoice->slug );
 				$invoice->set_data( $document_data, $order );
 				$invoice->save();

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1222,7 +1222,12 @@ abstract class Order_Document_Methods extends Order_Document {
 	}
 
 	public function document_notes() {
-		echo $this->get_document_notes();
+		$document_notes = $this->get_document_notes();
+		if( $document_notes == strip_tags( $document_notes ) ) {
+			echo nl2br($document_notes);
+		} else {
+			echo $document_notes;
+		}
 	}
 
 


### PR DESCRIPTION
closes #136

- Fixes duplicate slashes pointed in the issue #136 
- Allows special characters '"!#$%&/()=
- Respects line breaks (clicking enter)
- Respects line breaks with `<br>`

##### 1) Before save (current version)
```
eieieieieiei

apapapapapa
<br><br>
eieieieieiei
```

##### 2) After save (current version)
```
eieieieieiei<br />
<br />
apapapapapa<br />
<br />
eieieieieiei
```
##### 3) Before save (this branch)
```
eieieieieiei

apapapapapa
<br><br>
eieieieieiei
```
##### 4) After save (this branch)
```
eieieieieiei

apapapapapa
<br><br>
eieieieieiei
```
##### 5) After saving legacy notes (2) (this branch)
```
eieieieieiei<br />
<br />
apapapapapa<br />
<br />
eieieieieiei
```

