### PR TITLE
allow filtering button classes using 

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -182,19 +182,24 @@ class Admin {
 			$icon = !empty($document->icon) ? $document->icon : WPO_WCPDF()->plugin_url() . "/assets/images/generic_document.png";
 			if ( $document = wcpdf_get_document( $document->get_type(), $order ) ) {
 				$document_title = is_callable( array( $document, 'get_title' ) ) ? $document->get_title() : $document_title;
+				$document_exists = is_callable( array( $document, 'exists' ) ) ? $document->exists() : false;
 				$listing_actions[$document->get_type()] = array(
-					'url'		=> wp_nonce_url( admin_url( "admin-ajax.php?action=generate_wpo_wcpdf&document_type={$document->get_type()}&order_ids=" . WCX_Order::get_id( $order ) ), 'generate_wpo_wcpdf' ),
-					'img'		=> $icon,
-					'alt'		=> "PDF " . $document_title,
-					'exists'	=> is_callable( array( $document, 'exists' ) ) ? $document->exists() : false,
+					'url'    => wp_nonce_url( admin_url( "admin-ajax.php?action=generate_wpo_wcpdf&document_type={$document->get_type()}&order_ids=" . WCX_Order::get_id( $order ) ), 'generate_wpo_wcpdf' ),
+					'img'    => $icon,
+					'alt'    => "PDF " . $document_title,
+					'exists' => $document_exists,
+					'class'  => apply_filters( 'wpo_wcpdf_action_button_class', $document_exists ? "exists " . $document->get_type() : $document->get_type(), $document ),
 				);
 			}
 		}
 
-		$listing_actions = apply_filters( 'wpo_wcpdf_listing_actions', $listing_actions, $order );			
+		$listing_actions = apply_filters( 'wpo_wcpdf_listing_actions', $listing_actions, $order );
 
 		foreach ($listing_actions as $action => $data) {
-			?><a href="<?php echo $data['url']; ?>" class="button tips wpo_wcpdf <?php echo $data['exists'] == true ? "exists " . $action : $action; ?>" target="_blank" alt="<?php echo $data['alt']; ?>" data-tip="<?php echo $data['alt']; ?>">
+			if ( !isset( $data['class'] ) ) {
+				$data['class'] = $data['exists'] ? "exists " . $action : $action;
+			}
+			?><a href="<?php echo $data['url']; ?>" class="button tips wpo_wcpdf <?php echo $data['class']; ?>" target="_blank" alt="<?php echo $data['alt']; ?>" data-tip="<?php echo $data['alt']; ?>">
 				<img src="<?php echo $data['img']; ?>" alt="<?php echo $data['alt']; ?>" width="16">
 			</a><?php
 		}


### PR DESCRIPTION
using `wpo_wcpdf_action_button_class`  the appearance of the button can now be controlled more easily. Here's an example implementation showing a grey checkmark for created documents and a green checkmark for printed ones:
```php
add_action( 'wpo_wcpdf_before_document', function( $document_type, $order ) {
	$order->update_meta_data( "wpo_wcpdf_{$document_type}_last_printed", date_i18n( 'Y-m-d H:i:s' ) );
	$order->save_meta_data();
}, 10, 2 );

add_filter( 'wpo_wcpdf_action_button_class', function( $class, $document ) {
	if ( $order = $document->order ) {
		$document_type = $document->get_type();
		$printed = $order->get_meta( "wpo_wcpdf_{$document_type}_last_printed" );
		if ( !empty( $printed ) ) {
			$class .= " printed";
		}
	}
	return $class;
}, 10, 2 );

add_action('admin_enqueue_scripts', function(){
	wp_add_inline_style( 'wpo-wcpdf-order-styles', '.wpo_wcpdf.button.exists:not(.printed):after { color: grey !important; }' );
}, 99999 );
```

result:
![button-class-filter-result](https://user-images.githubusercontent.com/3217773/107028387-c8280080-67ad-11eb-9413-ef11ac1e48b1.png)
