### PR TITLE
Fix translation in get_payment_method()

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -430,7 +430,7 @@ abstract class Order_Document_Methods extends Order_Document {
 			$payment_method_title = WCX_Order::get_prop( $this->order, 'payment_method_title', 'view' );
 		}
 
-		$payment_method = __( $payment_method_title, 'woocommerce' );
+		$payment_method = __( ucfirst($payment_method_title), 'woocommerce' );
 
 		return apply_filters( 'wpo_wcpdf_payment_method', $payment_method, $this );
 	}


### PR DESCRIPTION
Fix translation for payment method.

Currently if the payment method is set to "**Other**" this method returns the string "**other**" without the first capital letter.

But translations in the domain '**woocommerce**' start with a capital letter. So in the case of a translation, this method returns the payment method in English instead of the translation because it cannot find a match.