### PR TITLE
Invoice date set before generating document not being respected

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -393,15 +393,15 @@ class Admin {
 	public function get_current_values_for_document( $document, $data ) {
 		$current = array(
 			'number' => array(
-				'plain'     => $document->exists() && ! empty( $document->get_number() ) ? $document->get_number()->get_plain() : '',
-				'formatted' => $document->exists() && ! empty( $document->get_number() ) ? $document->get_number()->get_formatted() : '',
+				'plain'     => ! empty( $document->get_number() ) ? $document->get_number()->get_plain() : '',
+				'formatted' => ! empty( $document->get_number() ) ? $document->get_number()->get_formatted() : '',
 				'name'      => "_wcpdf_{$document->slug}_number",
 			),
 			'date' => array(
-				'formatted' => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( wc_date_format().' @ '.wc_time_format() ) : '',
-				'date'      => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'Y-m-d' ) : date_i18n( 'Y-m-d' ),
-				'hour'      => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'H' ) : date_i18n( 'H' ),
-				'minute'    => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'i' ) : date_i18n( 'i' ),
+				'formatted' => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( wc_date_format().' @ '.wc_time_format() ) : '',
+				'date'      => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'Y-m-d' ) : date_i18n( 'Y-m-d' ),
+				'hour'      => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'H' ) : date_i18n( 'H' ),
+				'minute'    => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'i' ) : date_i18n( 'i' ),
 				'name'      => "_wcpdf_{$document->slug}_date",
 			),
 		);

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -581,6 +581,12 @@ class Admin {
 			if ( $invoice = wcpdf_get_invoice( $order ) ) {
 				$document_data = $this->process_order_document_form_data( $_POST, $invoice->slug );
 				$invoice->set_data( $document_data, $order );
+
+				// check if we have number, and if not generate one
+				if( $invoice->get_date() && ! $invoice->get_number() && is_callable( array( $invoice, 'init_number' ) ) ) {
+					$invoice->init_number();
+				}
+
 				$invoice->save();
 			}
 
@@ -855,14 +861,14 @@ class Admin {
 
 		$date_entered = ! empty( $form_data['_wcpdf_'.$document_slug.'_date'] ) && ! empty( $form_data['_wcpdf_'.$document_slug.'_date']['date'] );
 		if( $date_entered ) {
-			$date = $form_data['_wcpdf_'.$document_slug.'_date']['date'];
-			$hour = ! empty( $form_data['_wcpdf_'.$document_slug.'_date']['hour'] ) ? $form_data['_wcpdf_'.$document_slug.'_date']['hour'] : '00';
-			$minute = ! empty( $form_data['_wcpdf_'.$document_slug.'_date']['minute'] ) ? $form_data['_wcpdf_'.$document_slug.'_date']['minute'] : '00';
+			$date         = $form_data['_wcpdf_'.$document_slug.'_date']['date'];
+			$hour         = ! empty( $form_data['_wcpdf_'.$document_slug.'_date']['hour'] ) ? $form_data['_wcpdf_'.$document_slug.'_date']['hour'] : '00';
+			$minute       = ! empty( $form_data['_wcpdf_'.$document_slug.'_date']['minute'] ) ? $form_data['_wcpdf_'.$document_slug.'_date']['minute'] : '00';
 
 			// clean & sanitize input
-			$date = date( 'Y-m-d', strtotime( $date ) );
-			$hour = sprintf('%02d', intval( $hour ));
-			$minute = sprintf('%02d', intval( $minute ) );
+			$date         = date( 'Y-m-d', strtotime( $date ) );
+			$hour         = sprintf('%02d', intval( $hour ));
+			$minute       = sprintf('%02d', intval( $minute ) );
 			$data['date'] = "{$date} {$hour}:{$minute}:00";
 
 		} elseif ( ! $date_entered && !empty( $_POST['_wcpdf_'.$document_slug.'_number'] ) ) {
@@ -900,7 +906,7 @@ class Admin {
 				'b'		=> array(),
 			);
 			// sanitize
-			$notes = sanitize_textarea_field( wp_kses( $form_data['_wcpdf_'.$document_slug.'_notes'], $allowed_html ) );
+			$notes         = sanitize_textarea_field( wp_kses( $form_data['_wcpdf_'.$document_slug.'_notes'], $allowed_html ) );
 			$data['notes'] = nl2br( $notes );
 		}
 

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -393,15 +393,15 @@ class Admin {
 	public function get_current_values_for_document( $document, $data ) {
 		$current = array(
 			'number' => array(
-				'plain'     => ! empty( $document->get_number() ) ? $document->get_number()->get_plain() : '',
-				'formatted' => ! empty( $document->get_number() ) ? $document->get_number()->get_formatted() : '',
+				'plain'     => $document->exists() && ! empty( $document->get_number() ) ? $document->get_number()->get_plain() : '',
+				'formatted' => $document->exists() && ! empty( $document->get_number() ) ? $document->get_number()->get_formatted() : '',
 				'name'      => "_wcpdf_{$document->slug}_number",
 			),
 			'date' => array(
-				'formatted' => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( wc_date_format().' @ '.wc_time_format() ) : '',
-				'date'      => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'Y-m-d' ) : date_i18n( 'Y-m-d' ),
-				'hour'      => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'H' ) : date_i18n( 'H' ),
-				'minute'    => ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'i' ) : date_i18n( 'i' ),
+				'formatted' => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( wc_date_format().' @ '.wc_time_format() ) : '',
+				'date'      => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'Y-m-d' ) : date_i18n( 'Y-m-d' ),
+				'hour'      => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'H' ) : date_i18n( 'H' ),
+				'minute'    => $document->exists() && ! empty( $document->get_date() ) ? $document->get_date()->date_i18n( 'i' ) : date_i18n( 'i' ),
 				'name'      => "_wcpdf_{$document->slug}_date",
 			),
 		);

--- a/includes/documents/class-wcpdf-invoice.php
+++ b/includes/documents/class-wcpdf-invoice.php
@@ -67,7 +67,7 @@ class Invoice extends Order_Document_Methods {
 
 		if ( isset( $this->settings['display_date'] ) && $this->settings['display_date'] == 'order_date' && !empty( $this->order ) ) {
 			$this->set_date( WCX_Order::get_prop( $this->order, 'date_created' ) );
-		} else {
+		} elseif( empty( $this->get_date() ) ) {
 			$this->set_date( current_time( 'timestamp', true ) );
 		}
 


### PR DESCRIPTION
Also after setting the date to the future, if clicking "Set invoice number and date" the date showed was current, now fixed!

Also initiates the Invoice number if the date is set in the form data and the number is not.

closes #165