### PR TITLE
fix missing directory separator in distributed fonts path

### DIFF
--- a/vendor/dompdf/dompdf/lib/fonts/dompdf_font_family_cache.dist.php
+++ b/vendor/dompdf/dompdf/lib/fonts/dompdf_font_family_cache.dist.php
@@ -1,6 +1,7 @@
 <?php
+// $distFontDir = $rootDir . '/lib/fonts'; // should work fine too?
+$distFontDir = trailingslashit( WPO_WCPDF()->plugin_path() ) . 'vendor' . DIRECTORY_SEPARATOR . 'dompdf' . DIRECTORY_SEPARATOR . 'dompdf' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'fonts' . DIRECTORY_SEPARATOR;
 
-$distFontDir = WPO_WCPDF()->plugin_path() . 'vendor' . DIRECTORY_SEPARATOR . 'dompdf' . DIRECTORY_SEPARATOR . 'dompdf' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'fonts' . DIRECTORY_SEPARATOR;
 return array(
     'sans-serif' =>
         array(
@@ -92,6 +93,34 @@ return array(
             'bold_italic' => $distFontDir . 'DejaVuSerif-BoldItalic',
             'italic' => $distFontDir . 'DejaVuSerif-Italic',
             'normal' => $distFontDir . 'DejaVuSerif'
-        )
+        ),
+    'open sans' => 
+        array(
+        'normal' => $distFontDir . 'OpenSans-Normal',
+        'bold' => $distFontDir . 'OpenSans-Bold',
+        'italic' => $distFontDir . 'OpenSans-Italic',
+        'bold_italic' => $distFontDir . 'OpenSans-BoldItalic',
+    ),
+    'segoe' => 
+        array(
+            'normal' => $distFontDir . 'Segoe-Normal',
+            'bold' => $distFontDir . 'Segoe-Bold',
+            'italic' => $distFontDir . 'Segoe-Italic',
+            'bold_italic' => $distFontDir . 'Segoe-BoldItalic',
+        ),
+    'roboto slab' => 
+        array(
+            'normal' => $distFontDir . 'RobotoSlab-Normal',
+            'bold' => $distFontDir . 'RobotoSlab-Bold',
+            'italic' => $distFontDir . 'RobotoSlab-Italic',
+            'bold_italic' => $distFontDir . 'RobotoSlab-BoldItalic',
+        ),
+    'currencies' => 
+        array(
+            'normal' => $distFontDir . 'currencies',
+            'bold' => $distFontDir . 'currencies',
+            'italic' => $distFontDir . 'currencies',
+            'bold_italic' => $distFontDir . 'currencies',
+        ),
 )
 ?>


### PR DESCRIPTION
When the font folder in the temporary wcpdf folder is cleared (but not deleted) or when the font cache files (`.ufm.php`  and `.afm.php`) are deleted for whatever reason (most likely as a result of a false positive in a virus scan), the fonts can no longer be properly loaded and texts appear stacked.

dompdf actually provides a built-in fallback to 'distributed' (bundled) fonts if fonts cannot be loaded from the fonts path, but our version was missing a slash (`DIRECTORY_SEPARATOR`) in the path, so that this fallback would work either.

This PR fixes both the fallback and also adds the extra fonts we bundle by default to it