### PR TITLE
Fix issue with long URLs in the notes area

### DIFF
--- a/templates/Simple/style.css
+++ b/templates/Simple/style.css
@@ -234,6 +234,7 @@ dd:after {
 .document-notes,
 .customer-notes {
 	margin-top: 5mm;
+	word-wrap: break-word;
 }
 
 table.totals {


### PR DESCRIPTION
With this small addition, this issue seems to be solved:

![image](https://user-images.githubusercontent.com/38109855/124826516-eb183580-df42-11eb-8f9f-86d021783f62.png)

Closes: #196