### PR TITLE
Template path portability

### DIFF
--- a/includes/class-wcpdf-assets.php
+++ b/includes/class-wcpdf-assets.php
@@ -124,7 +124,8 @@ class Assets {
 				'wpo-wcpdf-admin',
 				'wpo_wcpdf_admin',
 				array(
-					'ajaxurl'		=> admin_url( 'admin-ajax.php' ),
+					'ajaxurl'        => admin_url( 'admin-ajax.php' ),
+					'template_paths' => WPO_WCPDF()->settings->get_installed_templates(),
 				)
 			);
 

--- a/includes/class-wcpdf-documents.php
+++ b/includes/class-wcpdf-documents.php
@@ -59,6 +59,8 @@ class Documents {
 
 		// Allow plugins to add their own documents
 		$this->documents = apply_filters( 'wpo_wcpdf_document_classes', $this->documents );
+
+		do_action( 'wpo_wcpdf_init_documents' );
 	}
 
 	/**

--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -347,6 +347,12 @@ class Install {
 			update_option( 'wpo_wcpdf_settings_debug', $debug_settings );
 		}
 
+		// 2.10.0-dev: migrate template path to template ID
+		if ( version_compare( $installed_version, '2.10.0-dev', '<' ) ) {
+			if ( ! empty( WPO_WCPDF()->settings ) && is_callable( array( WPO_WCPDF()->settings, 'maybe_migrate_template_paths' ) ) ) {
+				WPO_WCPDF()->settings->maybe_migrate_template_paths();
+			}
+		}
 	}
 
 	/**

--- a/includes/class-wcpdf-settings-general.php
+++ b/includes/class-wcpdf-settings-general.php
@@ -64,7 +64,7 @@ class Settings_General {
 				'args'		=> array(
 					'option_name'	=> $option_name,
 					'id'			=> 'template_path',
-					'options' 		=> $this->find_templates(),
+					'options' 		=> $this->get_installed_templates_list(),
 					/* translators: 1,2. template paths */
 					'description'	=> sprintf( __( 'Want to use your own template? Copy all the files from <code>%1$s</code> to your (child) theme in <code>%2$s</code> to customize them' , 'woocommerce-pdf-invoices-packing-slips' ), $plugin_template_path, $theme_template_path),
 				)
@@ -272,6 +272,29 @@ class Settings_General {
 				}
 			}
 		}
+	}
+
+	public function get_installed_templates_list() {
+		$installed_templates = WPO_WCPDF()->settings->get_installed_templates();
+		$template_list = array();
+		foreach ( $installed_templates as $path => $template_id ) {
+			$template_name = basename( $template_id );
+			$group = dirname( $template_id );
+			switch ( $group ) {
+				case 'theme':
+					$template_name = sprintf( '%s (%s)', $template_name, __( 'Theme', 'woocommerce-pdf-invoices-packing-slips' ) );
+					break;
+				case 'default':
+				case 'premium_plugin':
+					// no suffix
+					break;
+				default:
+					$template_name = sprintf( '%s (%s)', $template_name, __( 'Custom', 'woocommerce-pdf-invoices-packing-slips' ) );
+					break;
+			}
+			$template_list[$template_id] = $template_name;
+		}
+		return $template_list;
 	}
 
 	/**

--- a/includes/class-wcpdf-settings-general.php
+++ b/includes/class-wcpdf-settings-general.php
@@ -281,13 +281,11 @@ class Settings_General {
 			$template_name = basename( $template_id );
 			$group = dirname( $template_id );
 			switch ( $group ) {
-				case 'theme':
-					$template_name = sprintf( '%s (%s)', $template_name, __( 'Theme', 'woocommerce-pdf-invoices-packing-slips' ) );
-					break;
 				case 'default':
 				case 'premium_plugin':
 					// no suffix
 					break;
+				case 'theme':
 				default:
 					$template_name = sprintf( '%s (%s)', $template_name, __( 'Custom', 'woocommerce-pdf-invoices-packing-slips' ) );
 					break;

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -226,7 +226,6 @@ class Settings {
 		} else {
 			// unknown template or full template path (legacy settings or filter override)
 			$template_path = $this->normalize_path( $selected_template );
-			// die($template_path);
 			
 			// add base path, checking if it's not already there
 			// alternative setups like Bedrock have WP_CONTENT_DIR & ABSPATH separated

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -12,6 +12,7 @@ if ( !class_exists( '\\WPO\\WC\\PDF_Invoices\\Settings' ) ) :
 class Settings {
 	public $options_page_hook;
 	private $installed_templates = array();
+	private $installed_templates_cache = array();
 	
 	function __construct()	{
 		$this->callbacks = include( 'class-wcpdf-settings-callbacks.php' );
@@ -291,6 +292,10 @@ class Settings {
 		
 		$this->installed_templates = $installed_templates;
 
+		if ( ! empty( $this->template_list_cache ) && array_diff_assoc( $this->template_list_cache, $this->installed_templates ) ) {
+			$this->set_template_list_cache( $this->installed_templates );
+		}
+
 		return $installed_templates;
 	}
 
@@ -323,6 +328,8 @@ class Settings {
 				$this->set_template_list_cache( $checked_list );
 			}
 
+			$this->installed_templates_cache = $checked_list;
+
 			return $checked_list;
 		} else {
 			return array();
@@ -330,6 +337,7 @@ class Settings {
 	}
 
 	public function set_template_list_cache( $template_list ) {
+		$this->template_list_cache = $template_list;
 		update_option( 'wpo_wcpdf_installed_template_paths', $template_list );
 	}
 

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -830,7 +830,7 @@ abstract class Order_Document {
 		if (empty($file)) {
 			$file = $this->type.'.php';
 		}
-		$path = WPO_WCPDF()->settings->get_template_path( $file );
+		$path = $this->get_template_path();
 		$file_path = "{$path}/{$file}";
 
 		$fallback_file_path = WPO_WCPDF()->plugin_path() . '/templates/Simple/' . $file;

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PDF Invoices & Packing Slips
  * Plugin URI: http://www.wpovernight.com
  * Description: Create, print & email PDF invoices & packing slips for WooCommerce orders.
- * Version: 2.9.3
+ * Version: 2.10.0-dev
  * Author: Ewout Fernhout
  * Author URI: http://www.wpovernight.com
  * License: GPLv2 or later
@@ -21,7 +21,7 @@ if ( !class_exists( 'WPO_WCPDF' ) ) :
 
 class WPO_WCPDF {
 
-	public $version = '2.9.3';
+	public $version = '2.10.0-dev';
 	public $plugin_basename;
 	public $legacy_mode;
 	public $legacy_textdomain;


### PR DESCRIPTION
This PR introduces a new method of storing the selected template in the database - instead of a relative path (e.g. `wp-content/plugins/woocommerce-pdf-invoices-packing-slips/templates/Simple`, it stores an "id" (e.g. `default/Simple`). When the template path is requested, this id is then matched with a list of paths that is maintained separately.
The "id" is in the form of `{$group}/{$template_name}`, where `group` is the array key that was used when registering the template base path (the folder that holds the actual template subfolders).

This should improve portability by solving a number of edge-case issues:

- Templates are stored outside of the `WP_CONTENT_DIR` (or `ABSPATH`) and conversion from relative path to absolute path fails
- Templates are symlinks (in certain setups using Bedrock)
- Template location is stored (for some reason) as an absolute path and the base path changes (versioning etc).

Working with a 'live' list of paths does come with the downside that when the path is needed early on in the process, any (third party) functions hooking into our filters may not have been applied yet, and the path is therefor not available yet. To solve this problem, I have implemented a 'cached' list of paths that is updated when:

- The settings are saved/updated ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/84ba7b8e8d92fc7516d89a0bb9bfacc96172b30c/includes/class-wcpdf-settings.php#L45))
- Later retrieval of the actual 'live' list returns a different list than the cached one. ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/84ba7b8e8d92fc7516d89a0bb9bfacc96172b30c/includes/class-wcpdf-settings.php#L295-L297))
- One or more paths in the cached list no longer exists ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/84ba7b8e8d92fc7516d89a0bb9bfacc96172b30c/includes/class-wcpdf-settings.php#L306-L329))

Migration of old paths occurs when:
- The plugin is updated to the new version (Lifecycle methods, [here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/84ba7b8e8d92fc7516d89a0bb9bfacc96172b30c/includes/class-wcpdf-install.php#L350-L355))
- The settings page is loaded ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/84ba7b8e8d92fc7516d89a0bb9bfacc96172b30c/includes/class-wcpdf-settings.php#L47))

As a safety precaution/fallback the plugin also still accepts paths as the setting ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/84ba7b8e8d92fc7516d89a0bb9bfacc96172b30c/includes/class-wcpdf-settings.php#L227-L241))

Known (minor) issues:

- Premium Templates before 2.13.1 registered the template search path relatively late (`init` with priority `9`), while there was also a relatively early call for the template-functions.php file ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/60516f1c081404cf95d9dc5e03754941cfbf4e65/includes/class-wcpdf-main.php#L31-L35), which is at `plugins_loaded` with priority `9`). This should be corrected by the cached path list update routines outlined above.
- Premium Templates before 2.13.1 uses the value of the selected template to dynamically change the hints for creating a custom template. Since the value no longer holds the path but an "id", the result is that rather than the actual path to copy from, that "id" is shown, which could lead to confusion.

Both of these issues are addressed in 2.13.1 but we should take into account that people may be using older versions.

A **new feature** that I have introduced is the possibility to use the same name "Simple" when copying the template to a (child-) theme. This will show up as "Simple (Theme)" in the list.

## Testing
Because this change touches on one of the most crucial settings of the plugin (telling it where to find the template files), we should very carefully test as many scenarios as possible. This includes (but is certainly not limited to):

- Simply upgrading the old plugin to the new version - checking that the path is migrated to the id, and the PDF can still be generated everywhere
- Upgrading with a setup that was using the official Simple template and had a copy of the Simple template in the theme (this would not be used in the current release because it required a unique name).
- Usage in combination with the Premium Templates extension (both current version 2.13.1 as well as the previous 2.13.0)
-  ... any possible edge case you can think of!

**Note:** There is no 'downgrade' routine available in a current release for the settings migration, so once migrated to the "id", when you go back from the version from this PR/branch to the current release, the template setting will be lost (and should reset to "Simple").