### PR TITLE
Allow non-historical text settings

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -185,8 +185,8 @@ abstract class Order_Document {
 			'invoice_number_column',
 			'paper_size',
 			'font_subsetting',
-		) );
-		if ( in_array( $key, $non_historical_settings ) && isset($this->latest_settings) ) {
+		), $this );
+		if ( in_array( $key, $non_historical_settings ) && isset( $this->latest_settings ) ) {
 			$setting = isset( $this->latest_settings[$key] ) ? $this->latest_settings[$key] : $default;
 		} else {
 			$setting = isset( $this->settings[$key] ) ? $this->settings[$key] : $default;
@@ -620,12 +620,13 @@ abstract class Order_Document {
 	}
 
 	public function get_settings_text( $settings_key, $default = false, $autop = true ) {
+		$setting = $this->get_setting( $settings_key, $default );
 		// check for 'default' key existence
-		if ( ! empty( $this->settings[$settings_key] ) && is_array( $this->settings[$settings_key] ) && array_key_exists( 'default', $this->settings[$settings_key] ) ) {
-			$text = $this->settings[$settings_key]['default'];
+		if ( ! empty( $setting ) && is_array( $setting ) && array_key_exists( 'default', $setting ) ) {
+			$text = $setting['default'];
 		// fallback to first array element if default is not present
-		} elseif( ! empty( $this->settings[$settings_key] ) && is_array( $this->settings[$settings_key] ) ) {
-			$text = reset( $this->settings[$settings_key] );
+		} elseif( ! empty( $setting ) && is_array( $setting ) ) {
+			$text = reset( $setting );
 		}
 
 		// fallback to default


### PR DESCRIPTION
We have a filter `wpo_wcpdf_non_historical_settings` ([here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/3389013e1e3f851b0d35836864ba34d8847fa35e/includes/documents/abstract-wcpdf-order-document.php#L178-L188)) which allows specific settings to always read the latest settings, regardless of whether test mode or 'always use most current settings' is enabled.

For example, someone may want to exclude the filename so that they can change the filenames on existing invoices:
```php
add_filter( 'wpo_wcpdf_non_historical_settings', function( $non_historical_settings ){
	$non_historical_settings[] = 'filename';
	return $non_historical_settings;
} );
```
However, in our `get_settings_text()` method, we don't utilize the `get_setting()` method for text settings and read directly from the array instead. The result is that adding text settings to the non-historical settings will not have any effect (it will keep reading the 'old' value).

This PR addresses this issue.