### PR TITLE
Fail more gracefully during install/upgrade/downgrade

### DIFF
--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -58,7 +58,11 @@ class Install {
 			// new version number
 			update_option( $version_setting, WPO_WCPDF_VERSION );
 		} elseif ( $installed_version && version_compare( $installed_version, WPO_WCPDF_VERSION, '>' ) ) {
-			$this->downgrade( $installed_version );
+			try {
+				$this->downgrade( $installed_version );
+			} catch ( \Throwable $th ) {
+				wcpdf_log_error( sprintf( "Plugin downgrade procedure failed (downgrading from version %s to %s): %s", $installed_version, WPO_WCPDF_VERSION, $th->getMessage() ), 'critical', $th );
+			}
 			// downgrade version number
 			update_option( $version_setting, WPO_WCPDF_VERSION );
 		}

--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -42,9 +42,17 @@ class Install {
 		if ( version_compare( $installed_version, WPO_WCPDF_VERSION, '<' ) ) {
 
 			if ( ! $installed_version ) {
-				$this->install();
+				try {
+					$this->install();
+				} catch ( \Throwable $th ) {
+					wcpdf_log_error( sprintf( "Plugin install procedure failed (version %s): %s", WPO_WCPDF_VERSION, $th->getMessage() ), 'critical', $th );
+				}
 			} else {
-				$this->upgrade( $installed_version );
+				try {
+					$this->upgrade( $installed_version );
+				} catch ( \Throwable $th ) {
+					wcpdf_log_error( sprintf( "Plugin upgrade procedure failed (updating from version %s to %s): %s", $installed_version, WPO_WCPDF_VERSION, $th->getMessage() ), 'critical', $th );
+				}
 			}
 
 			// new version number


### PR DESCRIPTION
This replaces `require` with `include` in the `copy_fonts()` method, and logs an error when it fails (instead of crashing with an uncatchable error). Some WPCS has been applied too.

Additionally, all 3 Install procedures are now wrapped in `try ... catch` to avoid other fatal errors from breaking the site.

To test you could throw an error anywhere in the related code:
```php
throw new \Exception( "Error Processing Request", 1 );
```

and to test a failing `include`, the following line could be modified (adding a non-existing suffix, etc):
https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/5f728df5b594de10dcd13dd35e534c08285e4688/includes/class-wcpdf-main.php#L712

closes #245 