### PR TITLE
Use ISO currency code for RTL currencies when dompdf is used

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -1158,7 +1158,7 @@ abstract class Order_Document {
 		$callback = $filter[1];
 		$priority = isset( $filter[2] ) ? $filter[2] : 10;
 		$accepted_args = isset( $filter[3] ) ? $filter[3] : 1;
-		return compact( 'filter', 'hook_name', 'callback', 'accepted_args' );
+		return compact( 'hook_name', 'callback', 'priority', 'accepted_args' );
 	}
 
 }

--- a/includes/wcpdf-functions.php
+++ b/includes/wcpdf-functions.php
@@ -114,8 +114,11 @@ function wcpdf_get_packing_slip( $order, $init = false ) {
 }
 
 /**
- * Load HTML into (pluggable) PDF library, DomPDF 0.6 by default
+ * Load HTML into (pluggable) PDF library, DomPDF 1.0.2 by default
  * Use wpo_wcpdf_pdf_maker filter to change the PDF class (which can wrap another PDF library).
+ * 
+ * @param string $html
+ * @param array  $settings
  * @return PDF_Maker
  */
 function wcpdf_get_pdf_maker( $html, $settings = array() ) {
@@ -124,6 +127,16 @@ function wcpdf_get_pdf_maker( $html, $settings = array() ) {
 	}
 	$class = apply_filters( 'wpo_wcpdf_pdf_maker', '\\WPO\\WC\\PDF_Invoices\\PDF_Maker' );
 	return new $class( $html, $settings );
+}
+
+/**
+ * Check if the default PDF maker is used for creating PDF
+ * 
+ * @return bool whether the PDF maker is the default or not
+ */
+function wcpdf_pdf_maker_is_default() {
+	$default_pdf_maker = '\\WPO\\WC\\PDF_Invoices\\PDF_Maker';
+	return $default_pdf_maker == apply_filters( 'wpo_wcpdf_pdf_maker', $default_pdf_maker );
 }
 
 function wcpdf_pdf_headers( $filename, $mode = 'inline', $pdf = null ) {


### PR DESCRIPTION
closes #151 

This PR adds filters to replace the currency symbols that require RTL text direction support with their ISO currency code equivalents, **only** when the bundled dompdf library is used. We can't make assumptions about external libraries supporting RTL text, so we don't make the replacements when the PDF maker is overriden.

This means that people using our [mpdf extension](https://github.com/wpovernight/woocommerce-pdf-ips-mpdf) should see the actual currency symbol, not the ISO code!

I've also implemented two filters (`wpo_wcpdf_pdf_filters` & `wpo_wcpdf_html_filters`) that allow registering filters that should only be enabled during PDF (or HTML) creation, removing them automatically afterwards. This is used here so that these currency overrides don't apply to regular processes that run _after_ the PDF is created in the same request (e.g. "thank you" page, multiple emails being sent in a row, etc).
