### PR TITLE
Add wpo_wcpdf_pdf_filters and currency symbol fix to bulk document

### DIFF
--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -45,6 +45,8 @@ class Bulk_Document {
 		$this->type = $document_type;
 		$this->order_ids = $order_ids;
 		$this->is_bulk = true;
+
+		add_filter( 'wpo_wcpdf_pdf_filters', array( $this, 'pdf_currency_filters' ) );
 	}
 
 	public function get_type() {
@@ -149,6 +151,36 @@ class Bulk_Document {
 		$priority = isset( $filter[2] ) ? $filter[2] : 10;
 		$accepted_args = isset( $filter[3] ) ? $filter[3] : 1;
 		return compact( 'hook_name', 'callback', 'priority', 'accepted_args' );
+	}
+
+	public function pdf_currency_filters( $filters ) {
+		if ( isset( WPO_WCPDF()->settings->general_settings['currency_font'] ) ) {
+			$filters[] = array( 'woocommerce_currency_symbol', array( $this, 'use_currency_font' ), 10001, 2 );
+			// 'wpo_wcpdf_custom_styles' is actually an action, but WP handles them with the same functions
+			$filters[] = array( 'wpo_wcpdf_custom_styles', array( $this, 'currency_symbol_font_styles' ) );
+		}
+		return $filters;
+	}
+
+	/**
+	 * Use currency symbol font (when enabled in options)
+	 * @param string $currency_symbol Currency symbol
+	 * @param string $currency        Currency
+	 * 
+	 * @return string Currency symbol
+	 */
+	public function use_currency_font( $currency_symbol, $currency ) {
+		$currency_symbol = sprintf( '<span class="wcpdf-currency-symbol">%s</span>', $currency_symbol );
+		return $currency_symbol;
+	}
+
+	/**
+	 * Set currency font CSS
+	 */
+	public function currency_symbol_font_styles () {
+		?>
+		.wcpdf-currency-symbol { font-family: 'Currencies'; }
+		<?php
 	}
 
 }

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -77,6 +77,11 @@ class Bulk_Document {
 
 	public function get_html() {
 		do_action( 'wpo_wcpdf_before_html', $this->get_type(), $this );
+
+		// temporarily apply filters that need to be removed again after the html is generated
+		$html_filters = apply_filters( 'wpo_wcpdf_html_filters', array() );
+		$this->add_filters( $html_filters );
+
 		$html_content = array();
 		foreach ( $this->order_ids as $key => $order_id ) {
 			do_action( 'wpo_wcpdf_process_template_order', $this->get_type(), $order_id );
@@ -92,6 +97,9 @@ class Bulk_Document {
 		$this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
 		$html = $this->wrapper_document->wrap_html_content( $this->merge_documents( $html_content ) );
 		do_action( 'wpo_wcpdf_after_html', $this->get_type(), $this );
+
+		// remove temporary filters
+		$this->remove_filters( $html_filters );
 		
 		return $html;
 	}

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -54,6 +54,10 @@ class Bulk_Document {
 	public function get_pdf() {
 		do_action( 'wpo_wcpdf_before_pdf', $this->get_type(), $this );
 
+		// temporarily apply filters that need to be removed again after the pdf is generated
+		$pdf_filters = apply_filters( 'wpo_wcpdf_pdf_filters', array() );
+		$this->add_filters( $pdf_filters );
+
 		$html = $this->get_html();
 		$pdf_settings = array(
 			'paper_size'		=> apply_filters( 'wpo_wcpdf_paper_format', $this->wrapper_document->get_setting( 'paper_size', 'A4' ), $this->get_type(), $this ),
@@ -64,6 +68,9 @@ class Bulk_Document {
 		$pdf = apply_filters( 'wpo_wcpdf_pdf_data', $pdf_maker->output(), $this );
 		
 		do_action( 'wpo_wcpdf_after_pdf', $this->get_type(), $this );
+
+		// remove temporary filters
+		$this->remove_filters( $pdf_filters );
 
 		return $pdf;
 	}
@@ -119,6 +126,29 @@ class Bulk_Document {
 		$args = $args + $default_args;
 		$filename = $this->wrapper_document->get_filename( $context, $args );
 		return $filename;
+	}
+
+	protected function add_filters( $filters ) {
+		foreach ( $filters as $filter ) {
+			$filter = $this->normalize_filter_args( $filter );
+			add_filter( $filter['hook_name'], $filter['callback'], $filter['priority'], $filter['accepted_args'] );
+		}
+	}
+
+	protected function remove_filters( $filters ) {
+		foreach ( $filters as $filter ) {
+			$filter = $this->normalize_filter_args( $filter );
+			remove_filter( $filter['hook_name'], $filter['callback'], $filter['priority'] );
+		}
+	}
+
+	protected function normalize_filter_args( $filter ) {
+		$filter = array_values( $filter ); 
+		$hook_name = $filter[0];
+		$callback = $filter[1];
+		$priority = isset( $filter[2] ) ? $filter[2] : 10;
+		$accepted_args = isset( $filter[3] ) ? $filter[3] : 1;
+		return compact( 'hook_name', 'callback', 'priority', 'accepted_args' );
 	}
 
 }

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -45,8 +45,6 @@ class Bulk_Document {
 		$this->type = $document_type;
 		$this->order_ids = $order_ids;
 		$this->is_bulk = true;
-
-		add_filter( 'wpo_wcpdf_pdf_filters', array( $this, 'pdf_currency_filters' ) );
 	}
 
 	public function get_type() {
@@ -151,36 +149,6 @@ class Bulk_Document {
 		$priority = isset( $filter[2] ) ? $filter[2] : 10;
 		$accepted_args = isset( $filter[3] ) ? $filter[3] : 1;
 		return compact( 'hook_name', 'callback', 'priority', 'accepted_args' );
-	}
-
-	public function pdf_currency_filters( $filters ) {
-		if ( isset( WPO_WCPDF()->settings->general_settings['currency_font'] ) ) {
-			$filters[] = array( 'woocommerce_currency_symbol', array( $this, 'use_currency_font' ), 10001, 2 );
-			// 'wpo_wcpdf_custom_styles' is actually an action, but WP handles them with the same functions
-			$filters[] = array( 'wpo_wcpdf_custom_styles', array( $this, 'currency_symbol_font_styles' ) );
-		}
-		return $filters;
-	}
-
-	/**
-	 * Use currency symbol font (when enabled in options)
-	 * @param string $currency_symbol Currency symbol
-	 * @param string $currency        Currency
-	 * 
-	 * @return string Currency symbol
-	 */
-	public function use_currency_font( $currency_symbol, $currency ) {
-		$currency_symbol = sprintf( '<span class="wcpdf-currency-symbol">%s</span>', $currency_symbol );
-		return $currency_symbol;
-	}
-
-	/**
-	 * Set currency font CSS
-	 */
-	public function currency_symbol_font_styles () {
-		?>
-		.wcpdf-currency-symbol { font-family: 'Currencies'; }
-		<?php
 	}
 
 }


### PR DESCRIPTION
closes #263 

- Adds the `wpo_wcpdf_pdf_filters` filter (which was added [here](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/pull/255)) to the bulk document. 
- Also fixes the currency symbol not displaying in bulk documents as mentioned in this [ticket](https://wordpress.org/support/topic/currency-symbol-error-in-bulk-invoices/).



