### PR TITLE
WebP support checks for header logo, thumbnails and system config

### DIFF
--- a/includes/class-wcpdf-settings-callbacks.php
+++ b/includes/class-wcpdf-settings-callbacks.php
@@ -391,6 +391,17 @@ class Settings_Callbacks {
 				// don't display resolution
 			}
 
+			/*
+			 * .webp support can be disabled but still showing the image in settings.
+			 * We should add a notice because this will display an error when redering the PDF using DOMPDF.
+			 */
+			if ( 'webp' === wp_check_filetype( $attachment_src )['ext'] && ! function_exists( 'imagecreatefromwebp' ) ) {
+				printf(
+					'<div class="notice notice-warning inline" style="display:inline-block; width:auto;"><p>%s</p></div>',
+					wp_kses_post( 'File type <strong>webp</strong> is not supported locally! Please check your <strong>System Configurations</strong> under the <strong>Status</strong> tab.', 'woocommerce-pdf-invoices-packing-slips' ),
+				);
+			}
+
 			printf( '<img src="%1$s" style="display:block" id="img-%2$s"/>', esc_attr( $attachment_src ), esc_attr( $id ) );
 			if ( ! empty( $attachment_height ) && ! empty( $in_height ) ) {
 				$attachment_resolution = round( absint( $attachment_height ) / $in_height );

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -862,7 +862,7 @@ abstract class Order_Document_Methods extends Order_Document {
 			$contextless_site_url = str_replace(array('http://','https://'), '', trailingslashit(WP_CONTENT_URL));
 		}
 		$thumbnail_path = str_replace( $contextless_site_url, trailingslashit( $forwardslash_basepath ), $contextless_thumbnail_url);
-		
+
 		// fallback if thumbnail file doesn't exist
 		if (apply_filters('wpo_wcpdf_use_path', true) && !file_exists($thumbnail_path)) {
 			if ($thumbnail_id = $this->get_thumbnail_id( $product ) ) {
@@ -885,6 +885,17 @@ abstract class Order_Document_Methods extends Order_Document {
 		} else {
 			// load img with http url when filtered
 			$thumbnail = $thumbnail_img_tag_url;
+		}
+
+		/*
+		 * PHP GD library can be installed but 'webp' support could be disabled,
+		 * which turns the function 'imagecreatefromwebp()' inexistent,
+		 * leading to display an error in DOMPDF.
+		 * 
+		 * Check 'System configuration' in the Status tab for 'webp' support.
+		 */
+		if ( 'webp' === wp_check_filetype( $thumbnail_path )['ext'] && ! function_exists( 'imagecreatefromwebp' ) ) {
+			$thumbnail = '';
 		}
 
 		// die($thumbnail);

--- a/includes/views/dompdf-status.php
+++ b/includes/views/dompdf-status.php
@@ -29,6 +29,12 @@ $server_configs = apply_filters( 'wpo_wcpdf_server_configs' , array(
 		'result'   => function_exists('imagecreate'),
 		'fallback' => __( 'Required if you have images in your documents', 'woocommerce-pdf-invoices-packing-slips' ),
 	),
+	'WebP Support' => array(
+		'required' => __( 'Required when using .webp images', 'woocommerce-pdf-invoices-packing-slips' ),
+		'value'    => null,
+		'result'   => function_exists('imagecreatefromwebp'),
+		'fallback' => __( 'Required if you have .webp images in your documents', 'woocommerce-pdf-invoices-packing-slips' ),
+	),
 	// "PCRE" => array(
 	// 	"required" => true,
 	// 	"value"    => phpversion("pcre"),


### PR DESCRIPTION
closes #301

### Header logo

Displays a notice when using a `.webp` logo file and no WebP support:

![Captura de ecrã de 2022-01-26 11-45-25](https://user-images.githubusercontent.com/533273/151157716-761a7666-3b22-4d08-88ea-c35b9cf64108.png)

### Document items thumbnails

If using `.webp` files for thumbnails and no WebP support the file path will default to `empty`, not displaying the thumb in the PDF.

### System configuration

Display the WebP support status:

![Captura de ecrã de 2022-01-26 11-47-37](https://user-images.githubusercontent.com/533273/151158014-98f70ebb-8b90-4da2-9848-b26db0054859.png)

![Captura de ecrã de 2022-01-26 11-48-06](https://user-images.githubusercontent.com/533273/151158086-3508cbb1-e810-43f8-b6ee-b9456c37f812.png)

