### PR TITLE
Recombine non-historical settings with order settings

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -151,7 +151,7 @@ abstract class Order_Document {
 				$settings = (array) $order_settings + array_intersect_key( (array) $settings, array_flip( $this->get_non_historical_settings() ) );
 			}
 		}
-		if ( $this->storing_settings_enabled() && empty( $order_settings ) && !empty( $this->order ) ) {
+		if ( $this->storing_settings_enabled() && empty( $order_settings ) && ! empty( $this->order ) ) {
 			// this is either the first time the document is generated, or historical settings are disabled
 			// in both cases, we store the document settings
 			// exclude non historical settings from being saved in order meta

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -136,12 +136,12 @@ abstract class Order_Document {
 		}
 
 		// get historical settings if enabled
-		if ( !empty( $this->order ) && $this->use_historical_settings() == true ) {
+		if ( ! empty( $this->order ) && $this->use_historical_settings() == true ) {
 			$order_settings = WCX_Order::get_meta( $this->order, "_wcpdf_{$this->slug}_settings" );
-			if (!empty($order_settings) && !is_array($order_settings)) {
+			if ( ! empty( $order_settings ) && ! is_array( $order_settings ) ) {
 				$order_settings = maybe_unserialize( $order_settings );
 			}
-			if (!empty($order_settings) && is_array($order_settings)) {
+			if ( ! empty( $order_settings ) && is_array( $order_settings ) ) {
 				// ideally we should combine the order settings with the latest settings, so that new settings will
 				// automatically be applied to existing orders too. However, doing this by combining arrays is not
 				// possible because the way settings are currently stored means unchecked options are not included.

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -142,10 +142,13 @@ abstract class Order_Document {
 				$order_settings = maybe_unserialize( $order_settings );
 			}
 			if (!empty($order_settings) && is_array($order_settings)) {
-				// not sure what happens if combining with current settings will have unwanted side effects
-				// like unchecked options being enabled because missing = unchecked in historical - disabled for now
-				// $settings = (array) $order_settings + (array) $settings;
-				$settings = $order_settings;
+				// ideally we should combine the order settings with the latest settings, so that new settings will
+				// automatically be applied to existing orders too. However, doing this by combining arrays is not
+				// possible because the way settings are currently stored means unchecked options are not included.
+				// This means there is no way to tell whether an option didn't exist yet (in which case the new
+				// option should be added) or whether the option was simly unchecked (in which case it should not
+				// be overwritten). This can only be address by storing unchecked checkboxes too.
+				$settings = (array) $order_settings + array_intersect_key( (array) $settings, array_flip( $this->get_non_historical_settings() ) );
 			}
 		}
 		if ( $this->storing_settings_enabled() && empty( $order_settings ) && !empty( $this->order ) ) {


### PR DESCRIPTION
closes #327 

Since 2.13.0 we only store historical settings in the order meta, but this means that non-historical document settings can no longer be read from the order once the settings have been stored.

This PR recombines all non-historical settings with the order settings.