### PR TITLE
Checks if number store table exists before applying DB migration

### DIFF
--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -378,7 +378,7 @@ class Install {
 			global $wpdb;
 			$documents = WPO_WCPDF()->documents->get_documents( 'all' );
 			foreach ( $documents as $document ) {
-				if ( ! function_exists( 'WPO_WCPDF_Pro' ) && $document->get_type() != 'invoice' ) {
+				if ( $document->get_type() != 'invoice' ) {
 					$table_name = "{$wpdb->prefix}wcpdf_{$document->slug}_number";
 					if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" ) != $table_name ) {
 						continue;

--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -378,6 +378,12 @@ class Install {
 			global $wpdb;
 			$documents = WPO_WCPDF()->documents->get_documents( 'all' );
 			foreach ( $documents as $document ) {
+				if ( ! function_exists( 'WPO_WCPDF_Pro' ) && $document->get_type() != 'invoice' ) {
+					$table_name = "{$wpdb->prefix}wcpdf_{$document->slug}_number";
+					if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" ) != $table_name ) {
+						continue;
+					}
+				}
 				if ( is_callable( array( $document, 'get_sequential_number_store' ) ) ) {
 					$number_store = $document->get_sequential_number_store();
 					if ( ! empty( $number_store ) ) {

--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -378,11 +378,10 @@ class Install {
 			global $wpdb;
 			$documents = WPO_WCPDF()->documents->get_documents( 'all' );
 			foreach ( $documents as $document ) {
-				if ( $document->get_type() != 'invoice' ) {
-					$table_name = "{$wpdb->prefix}wcpdf_{$document->slug}_number";
-					if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" ) != $table_name ) {
-						continue;
-					}
+				$store_name = "{$document->slug}_number";
+				$table_name = apply_filters( "wpo_wcpdf_number_store_table_name", "{$wpdb->prefix}wcpdf_{$store_name}", $store_name, 'auto_increment' );
+				if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" ) != $table_name ) {
+					continue;
 				}
 				if ( is_callable( array( $document, 'get_sequential_number_store' ) ) ) {
 					$number_store = $document->get_sequential_number_store();

--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -379,7 +379,8 @@ class Install {
 			$documents = WPO_WCPDF()->documents->get_documents( 'all' );
 			foreach ( $documents as $document ) {
 				$store_name = "{$document->slug}_number";
-				$table_name = apply_filters( "wpo_wcpdf_number_store_table_name", "{$wpdb->prefix}wcpdf_{$store_name}", $store_name, 'auto_increment' );
+				$method     = WPO_WCPDF()->settings->get_sequential_number_store_method();
+				$table_name = apply_filters( "wpo_wcpdf_number_store_table_name", "{$wpdb->prefix}wcpdf_{$store_name}", $store_name, $method );
 				if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" ) != $table_name ) {
 					continue;
 				}


### PR DESCRIPTION
closes #331 

Because `get_sequential_number_store()` creates the number store table on the class instantiation, we need to check before that is the table exists. The **Packing Slip number** is only available in **Pro**, so I use that extension main function to create a condition for non `invoice` document number stores.

### Performed test

* Delete existing number stores
* Checkout this commit 96638af7419901e7f26c3edb679b39ac6dc7f4bd
* Generate number stores
* Checkout this branch
* DB migration

Logs:

`2022-02-22T17:22:37+00:00 INFO Default value changed for 'date' column to '1000-01-01 00:00:00' on database table: wp_wcpdf_invoice_number`