### PR TITLE
Escape text in settings wizard

### DIFF
--- a/includes/class-wcpdf-settings-callbacks.php
+++ b/includes/class-wcpdf-settings-callbacks.php
@@ -85,7 +85,7 @@ class Settings_Callbacks {
 			$type = 'text';
 		}
 
-		printf( '<input type="%1$s" id="%2$s" name="%3$s" value="%4$s" size="%5$s" placeholder="%6$s" %7$s/>', esc_attr( $type ), esc_attr( $id ), esc_attr( $setting_name ), esc_attr( $current ), esc_attr( $size ), esc_attr( $placeholder ), ! empty( $disabled ) ? 'disabled="disabled"' : '' );
+		printf( '<input type="%1$s" id="%2$s" name="%3$s" value="%4$s" size="%5$s" placeholder="%6$s" %7$s/>', esc_attr( $type ), esc_attr( $id ), esc_attr( $setting_name ),  wp_kses( stripslashes( esc_attr( $current ) ), array()), esc_attr( $size ), esc_attr( $placeholder ), ! empty( $disabled ) ? 'disabled="disabled"' : '' );
 	
 		// output description.
 		if ( ! empty( $description ) ) {

--- a/includes/views/setup-wizard/shop-name.php
+++ b/includes/views/setup-wizard/shop-name.php
@@ -10,6 +10,6 @@
 		'shop_address' => array( 'default' => '' ),
 	) );
 	?>
-	<input type="text" class="shop-name" placeholder="<?php esc_attr_e( 'Shop name', 'woocommerce-pdf-invoices-packing-slips' ); ?>" name="wcpdf_settings[wpo_wcpdf_settings_general][shop_name][default]" value="<?php echo esc_attr( array_pop( $current_settings['shop_name'] ) ); ?>">
+	<input type="text" class="shop-name" placeholder="<?php esc_attr_e( 'Shop name', 'woocommerce-pdf-invoices-packing-slips' ); ?>" name="wcpdf_settings[wpo_wcpdf_settings_general][shop_name][default]" value="<?php echo wp_kses( stripslashes( esc_attr( array_pop( $current_settings['shop_name'] ) ) ), array() ); ?>">
 	<textarea class="shop-address" placeholder="<?php esc_attr_e( 'Shop address', 'woocommerce-pdf-invoices-packing-slips' ); ?>" name="wcpdf_settings[wpo_wcpdf_settings_general][shop_address][default]"><?php echo esc_html( array_pop( $current_settings['shop_address'] ) ); ?></textarea>
 </div>


### PR DESCRIPTION
closes #299 

Escaped and stripped the slashes in the `input` element in the setup wizard:

Before
![Screenshot 2022-03-15 103831](https://user-images.githubusercontent.com/62675729/158415725-60bdca10-4257-4fd3-a4e3-e7e042c1eaef.png)
After
![Screenshot 2022-03-15 103155](https://user-images.githubusercontent.com/62675729/158415780-8357df24-3e67-4cf2-9bbe-f8e6be1dc917.png)

Same done for the displayed settings:

Before
![Screenshot 2022-03-15 104336](https://user-images.githubusercontent.com/62675729/158416345-78e9d5e6-bd45-4339-87d5-bb9c7d0c585c.png)

After
![Screenshot 2022-03-15 103311](https://user-images.githubusercontent.com/62675729/158416095-5c4f3c0b-9d76-4e54-a67d-f46ea601bda0.png)



