### PR TITLE
stripped slashes in wizard settings before saving to db

### DIFF
--- a/includes/class-wcpdf-setup-wizard.php
+++ b/includes/class-wcpdf-setup-wizard.php
@@ -246,6 +246,7 @@ class Setup_Wizard {
 						} else {
 							$settings[$key] = call_user_func( $sanitize_function, $value );
 						}
+						$settings[$key] = wp_kses( array_map( 'stripslashes', $value ), array() );
 					}
 					$current_settings = get_option( $option, array() );
 					$new_settings = $settings + $current_settings;

--- a/includes/class-wcpdf-setup-wizard.php
+++ b/includes/class-wcpdf-setup-wizard.php
@@ -242,11 +242,11 @@ class Setup_Wizard {
 						}
 
 						if ( is_array( $value ) ) {
+							$value = array_map( 'stripslashes_deep', $value );
 							$settings[$key] = array_map( $sanitize_function, $value );
 						} else {
 							$settings[$key] = call_user_func( $sanitize_function, $value );
 						}
-						$settings[$key] = wp_kses( array_map( 'stripslashes', $value ), array() );
 					}
 					$current_settings = get_option( $option, array() );
 					$new_settings = $settings + $current_settings;

--- a/includes/class-wcpdf-setup-wizard.php
+++ b/includes/class-wcpdf-setup-wizard.php
@@ -240,9 +240,10 @@ class Setup_Wizard {
 						} else {
 							$sanitize_function = 'sanitize_text_field';							
 						}
-
+						
+						$value = array_map( 'stripslashes_deep', $value );
+						
 						if ( is_array( $value ) ) {
-							$value = array_map( 'stripslashes_deep', $value );
 							$settings[$key] = array_map( $sanitize_function, $value );
 						} else {
 							$settings[$key] = call_user_func( $sanitize_function, $value );


### PR DESCRIPTION
closes #299 

stripped slashes from the wizard settings before saving to the database. the slashes that were printed on the frontend and the PDFs don't get printed after this