### PR TITLE
378 fixes bug filtered template path

### DIFF
--- a/includes/class-wcpdf-settings-general.php
+++ b/includes/class-wcpdf-settings-general.php
@@ -300,15 +300,14 @@ class Settings_General {
 	 */
 	public function find_templates() {
 		$installed_templates = array();
-
 		// get base paths
-		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( 'WC', 'template_path' ) ) ) ? WC()->template_path() : 'woocommerce/';
-		$template_base_path = untrailingslashit( $template_base_path );
-		$template_paths = array (
+		$template_base_path  = ( function_exists( 'WC' ) && is_callable( array( WC(), 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );
+		$template_base_path  = untrailingslashit( $template_base_path );
+		$template_paths      = array (
 			// note the order: child-theme before theme, so that array_unique filters out parent doubles
-			'default'		=> WPO_WCPDF()->plugin_path() . '/templates/',
-			'child-theme'	=> get_stylesheet_directory() . "/{$template_base_path}/pdf/",
-			'theme'			=> get_template_directory() . "/{$template_base_path}/pdf/",
+			'default'     => WPO_WCPDF()->plugin_path() . '/templates/',
+			'child-theme' => get_stylesheet_directory() . "/{$template_base_path}/pdf/",
+			'theme'       => get_template_directory() . "/{$template_base_path}/pdf/",
 		);
 
 		$template_paths = apply_filters( 'wpo_wcpdf_template_paths', $template_paths );
@@ -319,10 +318,10 @@ class Settings_General {
 			$forwardslash_basepath = str_replace( '\\', '/', WP_CONTENT_DIR );
 		}
 
-		foreach ($template_paths as $template_source => $template_path) {
+		foreach ( $template_paths as $template_source => $template_path ) {
 			$dirs = (array) glob( $template_path . '*' , GLOB_ONLYDIR );
 			
-			foreach ($dirs as $dir) {
+			foreach ( $dirs as $dir ) {
 				// we're stripping abspath to make the plugin settings more portable
 				$forwardslash_dir = str_replace( '\\', '/', $dir );
 				$installed_templates[ str_replace( $forwardslash_basepath, '', $forwardslash_dir ) ] = basename($dir);
@@ -332,7 +331,7 @@ class Settings_General {
 		// remove parent doubles
 		$installed_templates = array_unique($installed_templates);
 
-		if (empty($installed_templates)) {
+		if ( empty( $installed_templates ) ) {
 			// fallback to Simple template for servers with glob() disabled
 			$simple_template_path = str_replace( ABSPATH, '', $template_paths['default'] . 'Simple' );
 			$installed_templates[$simple_template_path] = 'Simple';

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -479,10 +479,7 @@ class Settings {
 			return $this->installed_templates;
 		}
 
-		$installed_templates = array();
-
-		// call the default WooCommerce filter here because by default it runs later and we could miss it
-		
+		$installed_templates = array();	
 
 		// get base paths
 		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( 'WC', 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -479,28 +479,27 @@ class Settings {
 			return $this->installed_templates;
 		}
 
-		$installed_templates = array();	
-
+		$installed_templates = array();
 		// get base paths
-		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( WC(), 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );
-		$template_base_path = untrailingslashit( $template_base_path );
-		$template_paths = array (
+		$template_base_path  = ( function_exists( 'WC' ) && is_callable( array( WC(), 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );
+		$template_base_path  = untrailingslashit( $template_base_path );
+		$template_paths      = array (
 			// note the order: theme before child-theme, so that child theme is always preferred (overwritten)
-			'default'		=> WPO_WCPDF()->plugin_path() . '/templates/',
-			'theme'			=> get_template_directory() . "/{$template_base_path}/pdf/",
-			'child-theme'	=> get_stylesheet_directory() . "/{$template_base_path}/pdf/",
+			'default'     => WPO_WCPDF()->plugin_path() . '/templates/',
+			'theme'       => get_template_directory() . "/{$template_base_path}/pdf/",
+			'child-theme' => get_stylesheet_directory() . "/{$template_base_path}/pdf/",
 		);
 
 		$template_paths = apply_filters( 'wpo_wcpdf_template_paths', $template_paths );
 
-		foreach ($template_paths as $template_source => $template_path) {
+		foreach ( $template_paths as $template_source => $template_path ) {
 			$dirs = (array) glob( $template_path . '*' , GLOB_ONLYDIR );
 			
 			foreach ( $dirs as $dir ) {
-				$clean_dir = $this->normalize_path( $dir );
+				$clean_dir     = $this->normalize_path( $dir );
 				$template_name = basename( $clean_dir );
 				// let child theme override parent theme
-				$group = ( $template_source == 'child-theme' ) ? 'theme' : $template_source; 
+				$group = ( $template_source == 'child-theme' ) ? 'theme' : $template_source;
 				$installed_templates[ $clean_dir ] = "{$group}/{$template_name}" ;
 			}
 		}

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -481,8 +481,11 @@ class Settings {
 
 		$installed_templates = array();
 
+		// call the default WooCommerce filter here because by default it runs later and we could miss it
+		
+
 		// get base paths
-		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( 'WC', 'template_path' ) ) ) ? WC()->template_path() : 'woocommerce/';
+		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( 'WC', 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );
 		$template_base_path = untrailingslashit( $template_base_path );
 		$template_paths = array (
 			// note the order: theme before child-theme, so that child theme is always preferred (overwritten)

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -482,7 +482,7 @@ class Settings {
 		$installed_templates = array();	
 
 		// get base paths
-		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( 'WC', 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );
+		$template_base_path = ( function_exists( 'WC' ) && is_callable( array( WC(), 'template_path' ) ) ) ? WC()->template_path() : apply_filters( 'woocommerce_template_path', 'woocommerce/' );
 		$template_base_path = untrailingslashit( $template_base_path );
 		$template_paths = array (
 			// note the order: theme before child-theme, so that child theme is always preferred (overwritten)


### PR DESCRIPTION
closes #378

When "General settings" are called the `WC()->template_path()` is not callable, which ends to the hard coded `woocommerce/` default. Applying the WooCommerce filter here catches potential custom filtered paths.

![Captura de ecrã de 2022-06-22 16-15-58](https://user-images.githubusercontent.com/533273/175067073-3e1a2870-81f1-4ae0-92d1-4177bb4444c1.png)
