### PR TITLE
Add new filter to allow user to disable the documents' data removal

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -1054,13 +1054,13 @@ class Main {
 	 * Remove all invoice data when requested
 	 */
 	public function remove_order_personal_data_meta( $meta_to_remove ) {
-			$wcpdf_private_meta = array(
-				'_wcpdf_invoice_number'         => 'numeric_id',
-				'_wcpdf_invoice_number_data'    => 'array',
-				'_wcpdf_invoice_date'           => 'timestamp',
-				'_wcpdf_invoice_date_formatted' => 'date',
-			);
-		return $meta_to_remove;
+		$wcpdf_private_meta = array(
+			'_wcpdf_invoice_number'         => 'numeric_id',
+			'_wcpdf_invoice_number_data'    => 'array',
+			'_wcpdf_invoice_date'           => 'timestamp',
+			'_wcpdf_invoice_date_formatted' => 'date',
+		);
+		return $meta_to_remove + $wcpdf_private_meta;
 	}
 
 	/**

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -1052,13 +1052,16 @@ class Main {
 	 * Remove all invoice data when requested
 	 */
 	public function remove_order_personal_data_meta( $meta_to_remove ) {
-		$wcpdf_private_meta = array(
-			'_wcpdf_invoice_number'         => 'numeric_id',
-			'_wcpdf_invoice_number_data'    => 'array',
-			'_wcpdf_invoice_date'           => 'timestamp',
-			'_wcpdf_invoice_date_formatted' => 'date',
-		);
-		return $meta_to_remove + $wcpdf_private_meta;
+		if ( true === apply_filters( 'wpo_wcpdf_remove_order_personal_data_meta', true ) ) {
+			$wcpdf_private_meta = array(
+				'_wcpdf_invoice_number'         => 'numeric_id',
+				'_wcpdf_invoice_number_data'    => 'array',
+				'_wcpdf_invoice_date'           => 'timestamp',
+				'_wcpdf_invoice_date_formatted' => 'date',
+			);
+			return $meta_to_remove + $wcpdf_private_meta;
+		}
+		return $meta_to_remove;
 	}
 
 	/**

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -42,7 +42,7 @@ class Main {
 		add_action( 'wp_scheduled_delete', array( $this, 'schedule_temporary_files_cleanup' ) );
 
 		// remove private data
-		if ( true === apply_filters( 'wpo_wcpdf_remove_order_personal_data_meta', true ) ) {
+		if ( apply_filters( 'wpo_wcpdf_remove_order_personal_data', true ) ) {
 			add_action( 'woocommerce_privacy_remove_order_personal_data_meta', array( $this, 'remove_order_personal_data_meta' ), 10, 1 );
 			add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this, 'remove_order_personal_data' ), 10, 1 );
 		}

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -42,8 +42,10 @@ class Main {
 		add_action( 'wp_scheduled_delete', array( $this, 'schedule_temporary_files_cleanup' ) );
 
 		// remove private data
-		add_action( 'woocommerce_privacy_remove_order_personal_data_meta', array( $this, 'remove_order_personal_data_meta' ), 10, 1 );
-		add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this, 'remove_order_personal_data' ), 10, 1 );
+		if ( true === apply_filters( 'wpo_wcpdf_remove_order_personal_data_meta', true ) ) {
+			add_action( 'woocommerce_privacy_remove_order_personal_data_meta', array( $this, 'remove_order_personal_data_meta' ), 10, 1 );
+			add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this, 'remove_order_personal_data' ), 10, 1 );
+		}
 		// export private data
 		add_action( 'woocommerce_privacy_export_order_personal_data_meta', array( $this, 'export_order_personal_data_meta' ), 10, 1 );
 
@@ -1052,15 +1054,12 @@ class Main {
 	 * Remove all invoice data when requested
 	 */
 	public function remove_order_personal_data_meta( $meta_to_remove ) {
-		if ( true === apply_filters( 'wpo_wcpdf_remove_order_personal_data_meta', true ) ) {
 			$wcpdf_private_meta = array(
 				'_wcpdf_invoice_number'         => 'numeric_id',
 				'_wcpdf_invoice_number_data'    => 'array',
 				'_wcpdf_invoice_date'           => 'timestamp',
 				'_wcpdf_invoice_date_formatted' => 'date',
 			);
-			return $meta_to_remove + $wcpdf_private_meta;
-		}
 		return $meta_to_remove;
 	}
 


### PR DESCRIPTION
This PR introduces the `wpo_wcpdf_remove_order_personal_data_meta` filter hook, which allows you to override the default behavior of the document data removal, enabled by default.

You can use the filter hook to disable the documents' data removal, this way:

```php
add_filter( 'wpo_wcpdf_remove_order_personal_data', '__return_false' );
```

Closes: #456