### PR TITLE
Replaces yearly debug enable property with filter

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -1034,7 +1034,7 @@ abstract class Order_Document {
 			}
 			
 			// for yearly reset debugging only
-			if ( apply_filters( 'wpo_wcpdf_yearly_reset_debug_enable', false ) ) {
+			if ( apply_filters( 'wpo_wcpdf_enable_yearly_reset_debug', false ) ) {
 				$date = new \WC_DateTime( '1st January Next Year' );
 			}
 			
@@ -1120,7 +1120,7 @@ abstract class Order_Document {
 		$now                = new \WC_DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 		
 		// for yearly reset debugging only
-		if ( apply_filters( 'wpo_wcpdf_yearly_reset_debug_enable', false ) ) {
+		if ( apply_filters( 'wpo_wcpdf_enable_yearly_reset_debug', false ) ) {
 			$now = new \WC_DateTime( '1st January Next Year' );
 		}
 		
@@ -1192,7 +1192,7 @@ abstract class Order_Document {
 		$current_year = date_i18n( 'Y' );
 		
 		// for yearly reset debugging only
-		if ( apply_filters( 'wpo_wcpdf_yearly_reset_debug_enable', false ) ) {
+		if ( apply_filters( 'wpo_wcpdf_enable_yearly_reset_debug', false ) ) {
 			$next_year    = new \WC_DateTime( '1st January Next Year' );
 			$current_year = intval( $next_year->date_i18n( 'Y' ) );
 		}

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -1034,7 +1034,7 @@ abstract class Order_Document {
 			}
 			
 			// for yearly reset debugging only
-			if ( WPO_WCPDF()->yearly_reset_debug ) {
+			if ( apply_filters( 'wpo_wcpdf_yearly_reset_debug_enable', false ) ) {
 				$date = new \WC_DateTime( '1st January Next Year' );
 			}
 			
@@ -1120,7 +1120,7 @@ abstract class Order_Document {
 		$now                = new \WC_DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 		
 		// for yearly reset debugging only
-		if ( WPO_WCPDF()->yearly_reset_debug ) {
+		if ( apply_filters( 'wpo_wcpdf_yearly_reset_debug_enable', false ) ) {
 			$now = new \WC_DateTime( '1st January Next Year' );
 		}
 		
@@ -1192,7 +1192,7 @@ abstract class Order_Document {
 		$current_year = date_i18n( 'Y' );
 		
 		// for yearly reset debugging only
-		if ( WPO_WCPDF()->yearly_reset_debug ) {
+		if ( apply_filters( 'wpo_wcpdf_yearly_reset_debug_enable', false ) ) {
 			$next_year    = new \WC_DateTime( '1st January Next Year' );
 			$current_year = intval( $next_year->date_i18n( 'Y' ) );
 		}

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -22,7 +22,6 @@ if ( ! class_exists( 'WPO_WCPDF' ) ) :
 class WPO_WCPDF {
 
 	public $version = '3.2.6';
-	public $yearly_reset_debug = false; // set 'true' only for debugging
 	public $plugin_basename;
 	public $legacy_mode;
 	public $legacy_textdomain;


### PR DESCRIPTION
I was thinking on this over the weekend, if for some reason we forgot the debug enabled and push changes to the branch and nobody notice could be problematic for customers, so I think we should use a filter instead.