### PR TITLE
Bail is document data is empty when saving order

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -663,17 +663,21 @@ class Admin {
 	 */
 	public function save_invoice_number_date($post_id, $post) {
 		$post_type = get_post_type( $post_id );
-		if( $post_type == 'shop_order' ) {
+		if ( $post_type == 'shop_order' ) {
+			
 			// bail if this is not an actual 'Save order' action
-			if ( ! isset($_POST['action']) || $_POST['action'] != 'editpost' ) {
+			if ( ! isset( $_POST['action'] ) || $_POST['action'] != 'editpost' ) {
 				return;
 			}
+			
 			// Check if user is allowed to change invoice data
 			if ( ! $this->user_can_manage_document( 'invoice' ) ) {
 				return;
 			}
 
-			$order = wc_get_order( $post_id );
+			$form_data = [];
+			$order     = wc_get_order( $post_id );
+			
 			if ( $invoice = wcpdf_get_invoice( $order ) ) {
 				$is_new        = false === $invoice->exists();
 				$form_data     = stripslashes_deep( $_POST );
@@ -685,7 +689,7 @@ class Admin {
 				$invoice->set_data( $document_data, $order );
 
 				// check if we have number, and if not generate one
-				if( $invoice->get_date() && ! $invoice->get_number() && is_callable( array( $invoice, 'init_number' ) ) ) {
+				if ( $invoice->get_date() && ! $invoice->get_number() && is_callable( array( $invoice, 'init_number' ) ) ) {
 					$invoice->init_number();
 				}
 

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -675,9 +675,13 @@ class Admin {
 
 			$order = wc_get_order( $post_id );
 			if ( $invoice = wcpdf_get_invoice( $order ) ) {
-				$is_new = false === $invoice->exists();
-				$_POST = stripslashes_deep( $_POST );
-				$document_data = $this->process_order_document_form_data( $_POST, $invoice->slug );
+				$is_new        = false === $invoice->exists();
+				$request_data  = stripslashes_deep( $_POST );
+				$document_data = $this->process_order_document_form_data( $request_data, $invoice->slug );
+				if ( empty( $document_data ) ) {
+					return;
+				}
+				
 				$invoice->set_data( $document_data, $order );
 
 				// check if we have number, and if not generate one
@@ -694,7 +698,7 @@ class Admin {
 			}
 
 			// allow other documents to hook here and save their form data
-			do_action( 'wpo_wcpdf_on_save_invoice_order_data', $_POST, $order, $this );
+			do_action( 'wpo_wcpdf_on_save_invoice_order_data', $request_data, $order, $this );
 		}
 	}
 

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -676,8 +676,8 @@ class Admin {
 			$order = wc_get_order( $post_id );
 			if ( $invoice = wcpdf_get_invoice( $order ) ) {
 				$is_new        = false === $invoice->exists();
-				$request_data  = stripslashes_deep( $_POST );
-				$document_data = $this->process_order_document_form_data( $request_data, $invoice->slug );
+				$form_data     = stripslashes_deep( $_POST );
+				$document_data = $this->process_order_document_form_data( $form_data, $invoice->slug );
 				if ( empty( $document_data ) ) {
 					return;
 				}
@@ -698,7 +698,7 @@ class Admin {
 			}
 
 			// allow other documents to hook here and save their form data
-			do_action( 'wpo_wcpdf_on_save_invoice_order_data', $request_data, $order, $this );
+			do_action( 'wpo_wcpdf_on_save_invoice_order_data', $form_data, $order, $this );
 		}
 	}
 


### PR DESCRIPTION
I notice in a customer store strange order comments, and after investigating I found that when the order is saved, for example when changing the order status to completed, our plugin function `save_invoice_number_date()` is triggered. Because the document data is empty, and we don't do a check on that, the order comments were registered anyway here: https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/blob/5048ca51bcfed8db1eba4e0f5ae72ecdbf01bfa6/includes/class-wcpdf-admin.php#L692

These are the wrongly registered comments:

![Captura de ecrã de 2023-01-10 12-40-10](https://user-images.githubusercontent.com/533273/211554385-8c471e2a-2017-4434-8069-fed2d03420cc.png)

The PDF in this case was generated in the completed email trigger.