### PR TITLE
Adds a document object arg to PDF maker class

### DIFF
--- a/includes/class-wcpdf-pdf-maker.php
+++ b/includes/class-wcpdf-pdf-maker.php
@@ -13,9 +13,11 @@ if ( !class_exists( '\\WPO\\WC\\PDF_Invoices\\PDF_Maker' ) ) :
 class PDF_Maker {
 	public $html;
 	public $settings;
+	public $document;
 
-	public function __construct( $html, $settings = array() ) {
-		$this->html = $html;
+	public function __construct( $html, $settings = array(), $document = null ) {
+		$this->html     = $html;
+		$this->document = $document;
 
 		$default_settings = array(
 			'paper_size'		=> 'A4',

--- a/includes/class-wcpdf-pdf-maker.php
+++ b/includes/class-wcpdf-pdf-maker.php
@@ -50,9 +50,9 @@ class PDF_Maker {
 		$dompdf = new Dompdf( $options );
 		$dompdf->loadHtml( $this->html );
 		$dompdf->setPaper( $this->settings['paper_size'], $this->settings['paper_orientation'] );
-		$dompdf = apply_filters( 'wpo_wcpdf_before_dompdf_render', $dompdf, $this->html );
+		$dompdf = apply_filters( 'wpo_wcpdf_before_dompdf_render', $dompdf, $this->html, $options, $this->document );
 		$dompdf->render();
-		$dompdf = apply_filters( 'wpo_wcpdf_after_dompdf_render', $dompdf, $this->html );
+		$dompdf = apply_filters( 'wpo_wcpdf_after_dompdf_render', $dompdf, $this->html, $options, $this->document );
 
 		return $dompdf->output();
 	}

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -795,7 +795,7 @@ abstract class Order_Document {
 			'paper_orientation'	=> apply_filters( 'wpo_wcpdf_paper_orientation', 'portrait', $this->get_type(), $this ),
 			'font_subsetting'	=> $this->get_setting( 'font_subsetting', false ),
 		);
-		$pdf_maker    = wcpdf_get_pdf_maker( $this->get_html(), $pdf_settings );
+		$pdf_maker    = wcpdf_get_pdf_maker( $this->get_html(), $pdf_settings, $this );
 		$pdf          = $pdf_maker->output();
 		
 		do_action( 'wpo_wcpdf_after_pdf', $this->get_type(), $this );
@@ -820,7 +820,7 @@ abstract class Order_Document {
 			'paper_orientation'	=> apply_filters( 'wpo_wcpdf_paper_orientation', 'portrait', $this->get_type(), $this ),
 			'font_subsetting'	=> $this->get_setting( 'font_subsetting', false ),
 		);
-		$pdf_maker    = wcpdf_get_pdf_maker( $this->get_html(), $pdf_settings );
+		$pdf_maker    = wcpdf_get_pdf_maker( $this->get_html(), $pdf_settings, $this );
 		$pdf          = $pdf_maker->output();
 		
 		return $pdf;

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -60,7 +60,7 @@ class Bulk_Document {
 			'paper_orientation'	=> apply_filters( 'wpo_wcpdf_paper_orientation', 'portrait', $this->get_type(), $this ),
 			'font_subsetting'	=> $this->wrapper_document->get_setting( 'font_subsetting', false ),
 		);
-		$pdf_maker = wcpdf_get_pdf_maker( $html, $pdf_settings );
+		$pdf_maker = wcpdf_get_pdf_maker( $html, $pdf_settings, $this );
 		$pdf = apply_filters( 'wpo_wcpdf_pdf_data', $pdf_maker->output(), $this );
 		
 		do_action( 'wpo_wcpdf_after_pdf', $this->get_type(), $this );

--- a/includes/wcpdf-functions.php
+++ b/includes/wcpdf-functions.php
@@ -113,16 +113,17 @@ function wcpdf_get_packing_slip( $order, $init = false ) {
  * Load HTML into (pluggable) PDF library, DomPDF 1.0.2 by default
  * Use wpo_wcpdf_pdf_maker filter to change the PDF class (which can wrap another PDF library).
  * 
- * @param string $html
- * @param array  $settings
+ * @param string       $html
+ * @param array        $settings
+ * @param null|object  $document
  * @return WPO\WC\PDF_Invoices\PDF_Maker
  */
-function wcpdf_get_pdf_maker( $html, $settings = array() ) {
+function wcpdf_get_pdf_maker( $html, $settings = array(), $document = null ) {
 	if ( ! class_exists( '\\WPO\\WC\\PDF_Invoices\\PDF_Maker' ) ) {
 		include_once( WPO_WCPDF()->plugin_path() . '/includes/class-wcpdf-pdf-maker.php' );
 	}
 	$class = apply_filters( 'wpo_wcpdf_pdf_maker', '\\WPO\\WC\\PDF_Invoices\\PDF_Maker' );
-	return new $class( $html, $settings );
+	return new $class( $html, $settings, $document );
 }
 
 /**


### PR DESCRIPTION
A customer required a dynamic paper height for Packing Slip using mPDF extension. Currently the PDF maker class doesn't have a way to identify the current document. This PR addresses this by passing the document object in the construct arguments and also to render filters.