### PR TITLE
FIx: Replace the use of the deprecated `wcs_renewal_order_meta` hook

### DIFF
--- a/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
+++ b/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
@@ -13,14 +13,13 @@ if ( ! class_exists( '\\WPO\\WC\\PDF_Invoices\\Compatibility\\Third_Party_Plugin
 class Third_Party_Plugins {
 	function __construct()	{
 		// WooCommerce Subscriptions compatibility
-		if ( class_exists('WC_Subscriptions') ) {
+		if ( class_exists( 'WC_Subscriptions' ) ) {
 			if ( version_compare( \WC_Subscriptions::$version, '2.0', '<' ) ) {
 				add_action( 'woocommerce_subscriptions_renewal_order_created', array( $this, 'woocommerce_subscriptions_renewal_order_created' ), 10, 4 );
 			} elseif ( version_compare( \WC_Subscriptions::$version, '2.5', '<' ) ) {
 				add_filter( 'wcs_renewal_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 				add_filter( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 			} else {
-				// Replace the use of the deprecated wcs_renewal_order_meta hook
 				add_filter( 'wc_subscription_renewal_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 				add_filter( 'wc_subscriptions_resubscribe_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 			}

--- a/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
+++ b/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
@@ -16,11 +16,9 @@ class Third_Party_Plugins {
 		if ( class_exists('WC_Subscriptions') ) {
 			if ( version_compare( \WC_Subscriptions::$version, '2.0', '<' ) ) {
 				add_action( 'woocommerce_subscriptions_renewal_order_created', array( $this, 'woocommerce_subscriptions_renewal_order_created' ), 10, 4 );
-			} 
-
-			if ( version_compare( \WC_Subscriptions::$version, '2.0', '>=' ) && version_compare( \WC_Subscriptions::$version, '2.5', '<' ) ) {
-				add_action( 'wcs_renewal_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
-				add_action( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
+			} elseif ( version_compare( \WC_Subscriptions::$version, '2.5', '<' ) ) {
+				add_filter( 'wcs_renewal_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
+				add_filter( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 			} else {
 				// Replace the use of the deprecated wcs_renewal_order_meta hook
 				add_filter( 'wc_subscription_renewal_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );

--- a/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
+++ b/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
@@ -16,8 +16,14 @@ class Third_Party_Plugins {
 		if ( class_exists('WC_Subscriptions') ) {
 			if ( version_compare( \WC_Subscriptions::$version, '2.0', '<' ) ) {
 				add_action( 'woocommerce_subscriptions_renewal_order_created', array( $this, 'woocommerce_subscriptions_renewal_order_created' ), 10, 4 );
-			} else {
+			} 
+
+			if ( version_compare( \WC_Subscriptions::$version, '2.0', '>=' ) && version_compare( \WC_Subscriptions::$version, '2.5', '<' ) ) {
 				add_action( 'wcs_renewal_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
+				add_action( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
+			} else {
+				// Replace the use of the deprecated wcs_renewal_order_meta hook
+				add_action( 'wc_subscription_renewal_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 				add_action( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 			}
 		}

--- a/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
+++ b/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
@@ -23,8 +23,8 @@ class Third_Party_Plugins {
 				add_action( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 			} else {
 				// Replace the use of the deprecated wcs_renewal_order_meta hook
-				add_action( 'wc_subscription_renewal_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
-				add_action( 'wcs_resubscribe_order_meta', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
+				add_filter( 'wc_subscription_renewal_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
+				add_filter( 'wc_subscriptions_resubscribe_order_data', array( $this, 'wcs_renewal_order_meta' ), 10, 3 );
 			}
 		}
 


### PR DESCRIPTION
Closes #460 