### PR TITLE
Fix: font deletion bug after plugin upgrade

### DIFF
--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -216,9 +216,12 @@ class Install {
 		} else {
 			// don't try merging fonts with local when updating pre 2.0
 			$pre_2 = ( $installed_version == 'versionless' || version_compare( $installed_version, '2.0-dev', '<' ) );
-			$merge_with_local = $pre_2 ? false : true;
+			$merge_with_local = !$pre_2;
 			WPO_WCPDF()->main->copy_fonts( $font_path, $merge_with_local );
 		}
+
+        // to ensure fonts will be copied to the upload directory
+        delete_transient( 'wpo_wcpdf_subfolder_fonts_has_files' );
 		
 		// 1.5.28 update: copy next invoice number to separate setting
 		if ( $installed_version == 'versionless' || version_compare( $installed_version, '1.5.28', '<' ) ) {

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -522,7 +522,7 @@ class Main {
 		// * UNLESS the ‘UPLOADS’ constant is defined in wp-config (http://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder)
 		//
 		// May also be overridden by the wpo_wcpdf_tmp_path filter
-		
+
 		$wp_upload_base = $this->get_wp_upload_base();
 		if( $wp_upload_base ) {
 			if( $append_random_string && $code = $this->get_random_string() ) {
@@ -634,9 +634,6 @@ class Main {
 			$this->copy_fonts( $fonts_path );
 
 			// save to cache
-			if ( get_transient( 'wpo_wcpdf_subfolder_fonts_has_files' ) !== false ) {
-				delete_transient( 'wpo_wcpdf_subfolder_fonts_has_files' );
-			}
 			set_transient( 'wpo_wcpdf_subfolder_fonts_has_files', 'yes' , DAY_IN_SECONDS );
 		}
 	}


### PR DESCRIPTION
I tried several times to reproduce this issue by installing version 3.5.4 and upgrading to the latest version 3.5.5 multiple times, but I did not encounter the reported problem.

Upon reviewing the codes, I found out that the upgrade method always copies fonts in any situation. So, this issue is strange because everything seems fine!

I read support tickets related to this problem in both HelpScout and wordpress.org after the latest release, and I saw a few tickets related to the fonts issue, but none of them specifically referred to any problems associated with the "upgrade" process.

Also, about another individual's comment in the main topic (https://wordpress.org/support/topic/had-to-manually-reinstall-plugin-fonts/), I'm not sure whether he had this issue after the upgrade or not!

Anyway, as Yorden suggested, I implemented the deletion of "wpo_wcpdf_subfolder_fonts_has_files" transient to ensure that the problem does not occur. But I would like to revisit this issue later to make sure whether it originates from our side or the user's side.