### PR TITLE
Fix: allows the translation for the Shipping Notes strings

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1091,9 +1091,12 @@ abstract class Order_Document_Methods extends Order_Document {
 		}
 
 		// check document specific setting
-		if( isset($this->settings['display_customer_notes']) && $this->settings['display_customer_notes'] == 0 ) {
-			$shipping_notes = false;
+		if ( isset( $this->settings['display_customer_notes'] ) && $this->settings['display_customer_notes'] == 0 ) {
+			$shipping_notes = '';
 		}
+		
+		$shipping_notes = wp_strip_all_tags( $shipping_notes );
+		$shipping_notes = ! empty( $shipping_notes ) ? __( $shipping_notes, 'woocommerce-pdf-invoices-packing-slips' ) : false;
 
 		return apply_filters( 'wpo_wcpdf_shipping_notes', $shipping_notes, $this );
 	}


### PR DESCRIPTION
closes #558

Code snippet for testing:

```php
add_action( 'wpo_wcpdf_before_document', function( $document_type, $order ) {
	add_filter( 'gettext', 'wpo_translate_shipping_note', 10, 3 );
}, 10, 2 );

add_action( 'wpo_wcpdf_after_document', function( $document_type, $order ) {
	remove_filter( 'gettext', 'wpo_translate_shipping_note', 10, 3 );
}, 10, 2 );

function wpo_translate_shipping_note( $translation, $text, $domain ) {
	$translation = str_ireplace( 'Commande entièrement remboursée', 'Pedido reembolsado totalmente', $translation );
	return $translation;
}
```