### PR TITLE
New: filter hook to impeding Shipping Notes strip HTML tags

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1091,9 +1091,12 @@ abstract class Order_Document_Methods extends Order_Document {
 			$shipping_notes = '';
 		}
 		
-		$shipping_notes = wp_strip_all_tags( $shipping_notes );
+		if ( apply_filters( 'wpo_wcpdf_shipping_notes_strip_all_tags', true ) ) {
+			$shipping_notes = wp_strip_all_tags( $shipping_notes );
+		}
+		
 		$shipping_notes = ! empty( $shipping_notes ) ? __( $shipping_notes, 'woocommerce-pdf-invoices-packing-slips' ) : false;
-
+		
 		return apply_filters( 'wpo_wcpdf_shipping_notes', $shipping_notes, $this );
 	}
 	public function shipping_notes() {

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1091,7 +1091,7 @@ abstract class Order_Document_Methods extends Order_Document {
 			$shipping_notes = '';
 		}
 		
-		if ( apply_filters( 'wpo_wcpdf_shipping_notes_strip_all_tags', true ) ) {
+		if ( apply_filters( 'wpo_wcpdf_shipping_notes_strip_all_tags', false ) ) {
 			$shipping_notes = wp_strip_all_tags( $shipping_notes );
 		}
 		


### PR DESCRIPTION
closes #570

New filter to impede strip HTML tags from the Shipping Notes: `wpo_wcpdf_shipping_notes_strip_all_tags`