### PR TITLE
Tweak: removes legacy mode & textdomain from debug settings

### DIFF
--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -443,6 +443,30 @@ class Install {
 				update_option( 'wpo_wcpdf_settings_debug', $debug_settings );
 			}
 		}
+		
+		// 3.6-2-dev-1: check if not using a custom template and 'legacy_mode' is enabled, and disable it
+		if ( version_compare( $installed_version, '3.6.2-dev-1', '<' ) ) {
+			$debug_settings = get_option( 'wpo_wcpdf_settings_debug', array() );
+			if ( ! empty( $debug_settings['legacy_mode'] ) ) {
+				$templates_list        = WPO_WCPDF()->settings->general->get_installed_templates_list();
+				$using_custom_template = false;
+				
+				if ( ! empty( $templates_list ) ) {
+					foreach ( $templates_list as $template_id => $template_name ) {
+						if ( strpos( $template_name, '(Custom)' ) !== false ) {
+							$using_custom_template = true;
+							break;
+						}
+					}
+				}
+				
+				if ( ! $using_custom_template ) {
+					unset( $debug_settings['legacy_mode'] );
+					update_option( 'wpo_wcpdf_settings_debug', $debug_settings );
+				}
+			}
+		}
+		
 	}
 
 	/**

--- a/includes/settings/class-wcpdf-settings-debug.php
+++ b/includes/settings/class-wcpdf-settings-debug.php
@@ -494,30 +494,18 @@ class Settings_Debug {
 				'title'    => __( 'Debug settings', 'woocommerce-pdf-invoices-packing-slips' ),
 				'callback' => 'section',
 			),
-			array(
-				'type'     => 'setting',
-				'id'       => 'legacy_mode',
-				'title'    => __( 'Legacy mode', 'woocommerce-pdf-invoices-packing-slips' ),
-				'callback' => 'checkbox',
-				'section'  => 'debug_settings',
-				'args'     => array(
-					'option_name' => $option_name,
-					'id'          => 'legacy_mode',
-					'description' => __( "Legacy mode ensures compatibility with templates and filters from previous versions.", 'woocommerce-pdf-invoices-packing-slips' ),
-				)
-			),
-			array(
-				'type'     => 'setting',
-				'id'       => 'legacy_textdomain',
-				'title'    => __( 'Legacy textdomain fallback', 'woocommerce-pdf-invoices-packing-slips' ),
-				'callback' => 'checkbox',
-				'section'  => 'debug_settings',
-				'args'     => array(
-					'option_name' => $option_name,
-					'id'          => 'legacy_textdomain',
-					'description' => __( "Legacy textdomain fallback ensures compatibility with translation files from versions prior to 2017-05-15.", 'woocommerce-pdf-invoices-packing-slips' ),
-				)
-			),
+			// array(
+			// 	'type'     => 'setting',
+			// 	'id'       => 'legacy_mode',
+			// 	'title'    => __( 'Legacy mode', 'woocommerce-pdf-invoices-packing-slips' ),
+			// 	'callback' => 'checkbox',
+			// 	'section'  => 'debug_settings',
+			// 	'args'     => array(
+			// 		'option_name' => $option_name,
+			// 		'id'          => 'legacy_mode',
+			// 		'description' => __( "Legacy mode ensures compatibility with templates and filters from previous versions.", 'woocommerce-pdf-invoices-packing-slips' ),
+			// 	)
+			// ),
 			array(
 				'type'     => 'setting',
 				'id'	   => 'document_link_access_type',

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -24,7 +24,6 @@ class WPO_WCPDF {
 	public $version = '3.6.1';
 	public $plugin_basename;
 	public $legacy_mode;
-	public $legacy_textdomain;
 	public $third_party_plugins;
 	public $order_util;
 	public $settings;
@@ -70,11 +69,6 @@ class WPO_WCPDF {
 		add_action( 'admin_notices', array( $this, 'nginx_detected' ) );
 		add_action( 'admin_notices', array( $this, 'mailpoet_mta_detected' ) );
 		add_action( 'admin_notices', array( $this, 'rtl_detected' ) );
-
-		// legacy textdomain fallback
-		if ( $this->legacy_textdomain_enabled() === true ) {
-			add_filter( 'load_textdomain_mofile', array( $this, 'textdomain_fallback' ), 10, 2 );
-		}
 	}
 	
 	private function autoloaders() {
@@ -104,9 +98,6 @@ class WPO_WCPDF {
 		$dir    = trailingslashit( WP_LANG_DIR );
 
 		$textdomains = array( 'woocommerce-pdf-invoices-packing-slips' );
-		if ( $this->legacy_mode_enabled() === true ) {
-			$textdomains[] = 'wpo_wcpdf';
-		}
 
 		/**
 		 * Frontend/global Locale. Looks in:
@@ -248,17 +239,6 @@ class WPO_WCPDF {
 			$this->legacy_mode = isset($debug_settings['legacy_mode']);
 		}
 		return $this->legacy_mode;
-	}
-
-	/**
-	 * Check if legacy textdomain fallback is enabled
-	 */
-	public function legacy_textdomain_enabled() {
-		if (!isset($this->legacy_textdomain)) {
-			$debug_settings = get_option( 'wpo_wcpdf_settings_debug', array() );
-			$this->legacy_textdomain = isset($debug_settings['legacy_textdomain']);
-		}
-		return $this->legacy_textdomain;
 	}
 
 	/**


### PR DESCRIPTION
closes #553

I'm keeping the `legacy_mode` setting commented and the classes in case something goes wrong and we need to go back. I think we could safely remove them after some time.