### PR TITLE
Fix: bug when the temporary directory is not secured but the option exists in the database

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -686,9 +686,9 @@ class Main {
 	 * Get random string
 	 */
 	public function get_random_string () {
-		$code = sanitize_text_field( get_option( 'wpo_wcpdf_random_string' ) );
-		if( $code ) {
-			return $code;
+		$code = get_option( 'wpo_wcpdf_random_string', '' );
+		if ( ! empty( $code ) ) {
+			return esc_attr( $code );
 		} else {
 			return false;
 		}

--- a/includes/settings/class-wcpdf-settings-debug.php
+++ b/includes/settings/class-wcpdf-settings-debug.php
@@ -43,7 +43,6 @@ class Settings_Debug {
 		<h3><?php _e( 'Tools', 'woocommerce-pdf-invoices-packing-slips' ); ?></h3>
 		<div id="debug-tools">
 			<div class="wrapper">
-				<?php if( ! WPO_WCPDF()->main->get_random_string() ) : ?>
 				<div class="tool">
 					<h4><?php _e( 'Generate random temporary directory', 'woocommerce-pdf-invoices-packing-slips' ); ?></h4>
 					<p><?php _e( 'For security reasons, it is preferable to use a random name for the temporary directory.', 'woocommerce-pdf-invoices-packing-slips' ); ?></p>
@@ -68,7 +67,6 @@ class Settings_Debug {
 						?>
 					</form>
 				</div>
-				<?php endif; ?>
 				<div class="tool">
 					<h4><?php _e( 'Reinstall plugin fonts', 'woocommerce-pdf-invoices-packing-slips' ); ?></h4>
 					<p><?php _e( 'If you are experiencing issues with rendering fonts there might have been an issue during installation or upgrade.', 'woocommerce-pdf-invoices-packing-slips' ); ?></p>


### PR DESCRIPTION
closes #577

This will make the option to generate a new random string for the temporary directory always visible:

![Screenshot from 2023-08-18 16-41-47](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/assets/533273/5abd5fef-b94b-4cdb-8969-0861c1bd243f)
