### PR TITLE
Fix: bug of passing the wrong variable for the filtered order emails

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -461,7 +461,7 @@ class Admin {
 					$mailer           = WC()->mailer();
 					$order_emails     = array( 'new_order', 'cancelled_order', 'customer_processing_order', 'customer_completed_order', 'customer_invoice' );
 					$available_emails = apply_filters_deprecated( 'woocommerce_resend_order_emails_available', array( $order_emails ), '3.5.7', 'wpo_wcpdf_resend_order_emails_available' );
-					$available_emails = apply_filters( 'wpo_wcpdf_resend_order_emails_available', $order_emails, $order->get_id() );
+					$available_emails = apply_filters( 'wpo_wcpdf_resend_order_emails_available', $available_emails, $order->get_id() );
 					$mails            = $mailer->get_emails();
 					if ( ! empty( $mails ) && ! empty( $available_emails ) ) { ?>
 						<?php


### PR DESCRIPTION
This PR fixes the issue with filtered order emails not being added to the metabox, for example the Order Notification email from the Professional extension.