### PR TITLE
Fix: bug with HTML output using pretty links. Improved endpoint. 

### DIFF
--- a/includes/class-wcpdf-endpoint.php
+++ b/includes/class-wcpdf-endpoint.php
@@ -133,9 +133,6 @@ class Endpoint {
 		// handle additional query vars
 		$additional_vars = apply_filters( 'wpo_wcpdf_document_link_additional_vars', $additional_vars, $order, $document_type );
 		if ( ! empty( $additional_vars ) && is_array( $additional_vars ) ) {
-			if ( isset( $additional_vars['output'] ) && $this->pretty_links_enabled() ) {
-				unset( $additional_vars['output'] );
-			}
 			$document_link = add_query_arg( $additional_vars, $document_link );
 		}
 

--- a/includes/class-wcpdf-endpoint.php
+++ b/includes/class-wcpdf-endpoint.php
@@ -133,6 +133,9 @@ class Endpoint {
 		// handle additional query vars
 		$additional_vars = apply_filters( 'wpo_wcpdf_document_link_additional_vars', $additional_vars, $order, $document_type );
 		if ( ! empty( $additional_vars ) && is_array( $additional_vars ) ) {
+			if ( isset( $additional_vars['output'] ) && $this->pretty_links_enabled() ) {
+				unset( $additional_vars['output'] );
+			}
 			$document_link = add_query_arg( $additional_vars, $document_link );
 		}
 

--- a/includes/class-wcpdf-endpoint.php
+++ b/includes/class-wcpdf-endpoint.php
@@ -112,12 +112,13 @@ class Endpoint {
 		}
 
 		if ( $this->pretty_links_enabled() ) {
+			$output     = isset( $additional_vars['output'] ) ? esc_attr( $additional_vars['output'] ) : 'pdf';
 			$parameters = array(
 				$this->get_identifier(),
 				$document_type,
 				$order->get_id(),
 				$access_key,
-				'pdf'
+				$output
 			);
 			$document_link = trailingslashit( get_home_url() ) . implode( '/', $parameters );
 		} else {
@@ -132,6 +133,9 @@ class Endpoint {
 		// handle additional query vars
 		$additional_vars = apply_filters( 'wpo_wcpdf_document_link_additional_vars', $additional_vars, $order, $document_type );
 		if ( ! empty( $additional_vars ) && is_array( $additional_vars ) ) {
+			if ( isset( $additional_vars['output'] ) && $this->pretty_links_enabled() ) {
+				unset( $additional_vars['output'] );
+			}
 			$document_link = add_query_arg( $additional_vars, $document_link );
 		}
 

--- a/includes/class-wcpdf-endpoint.php
+++ b/includes/class-wcpdf-endpoint.php
@@ -10,7 +10,7 @@ if ( ! class_exists( '\\WPO\\WC\\PDF_Invoices\\Endpoint' ) ) :
 class Endpoint {
 
 	public $action_suffix = '_wpo_wcpdf';
-	public $events        = [ 'generate', 'printed' ];
+	public $events        = array( 'generate', 'printed' );
 	public $actions;
 	
 	protected static $_instance = null;
@@ -56,8 +56,8 @@ class Endpoint {
 	
 	public function add_endpoint() {
 		add_rewrite_rule(
-			'^'.$this->get_identifier().'/([^/]*)/([^/]*)/([^/]*)/([^/]*)?',
-			'index.php?action='.$this->actions['generate'].'&document_type=$matches[1]&order_ids=$matches[2]&access_key=$matches[3]&output=$matches[4]',
+			'^' . $this->get_identifier() . '/([^/]*)/([^/]*)/([^/]*)/([^/]*)?',
+			'index.php?action=' . $this->actions['generate'] . '&document_type=$matches[1]&order_ids=$matches[2]&access_key=$matches[3]&output=$matches[4]',
 			'top'
 		);
 	}

--- a/includes/class-wcpdf-endpoint.php
+++ b/includes/class-wcpdf-endpoint.php
@@ -23,7 +23,7 @@ class Endpoint {
 	}
 
 	public function __construct() {
-		if ( $this->is_enabled() ) {
+		if ( $this->pretty_links_enabled() ) {
 			add_action( 'init', array( $this, 'add_endpoint' ) );
 			add_action( 'query_vars', array( $this, 'add_query_vars' ) );
 			add_action( 'parse_request', array( $this, 'handle_document_requests' ) );
@@ -35,12 +35,12 @@ class Endpoint {
 	public function get_actions() {
 		$actions = [];
 		foreach ( $this->events as $event ) {
-			$actions[$event] = $event.$this->action_suffix;
+			$actions[ $event ] = $event . $this->action_suffix;
 		}
 		return $actions;
 	}
 
-	public function is_enabled() {
+	public function pretty_links_enabled() {
 		$debug_settings = get_option( 'wpo_wcpdf_settings_debug', array() );
 
 		if ( isset( $debug_settings['pretty_document_links'] ) ) {
@@ -56,8 +56,8 @@ class Endpoint {
 	
 	public function add_endpoint() {
 		add_rewrite_rule(
-			'^'.$this->get_identifier().'/([^/]*)/([^/]*)/([^/]*)?',
-			'index.php?action='.$this->actions['generate'].'&document_type=$matches[1]&order_ids=$matches[2]&access_key=$matches[3]',
+			'^'.$this->get_identifier().'/([^/]*)/([^/]*)/([^/]*)/([^/]*)?',
+			'index.php?action='.$this->actions['generate'].'&document_type=$matches[1]&order_ids=$matches[2]&access_key=$matches[3]&output=$matches[4]',
 			'top'
 		);
 	}
@@ -67,6 +67,7 @@ class Endpoint {
 		$vars[] = 'document_type';
 		$vars[] = 'order_ids';
 		$vars[] = 'access_key';
+		$vars[] = 'output';
 		return $vars;
 	}
 
@@ -74,11 +75,12 @@ class Endpoint {
 		global $wp;
 
 		if ( ! empty( $wp->query_vars['action'] ) && $this->actions['generate'] == $wp->query_vars['action'] ) {
-			if ( ! empty( $wp->query_vars['document_type'] ) && ! empty( $wp->query_vars['order_ids'] ) && ! empty( $wp->query_vars['access_key'] ) ) {
+			if ( ! empty( $wp->query_vars['document_type'] ) && ! empty( $wp->query_vars['order_ids'] ) && ! empty( $wp->query_vars['access_key'] ) && ! empty( $wp->query_vars['output'] ) ) {
 				$_REQUEST['action']        = $this->actions['generate'];
 				$_REQUEST['document_type'] = sanitize_text_field( $wp->query_vars['document_type'] );
 				$_REQUEST['order_ids']     = sanitize_text_field( $wp->query_vars['order_ids'] );
 				$_REQUEST['access_key']    = sanitize_text_field( $wp->query_vars['access_key'] );
+				$_REQUEST['output']        = sanitize_text_field( $wp->query_vars['output'] );
 				
 				do_action( 'wp_ajax_' . $this->actions['generate'] );
 			}
@@ -109,12 +111,13 @@ class Endpoint {
 			return '';
 		}
 
-		if ( $this->is_enabled() ) {
+		if ( $this->pretty_links_enabled() ) {
 			$parameters = array(
 				$this->get_identifier(),
 				$document_type,
 				$order->get_id(),
 				$access_key,
+				'pdf'
 			);
 			$document_link = trailingslashit( get_home_url() ) . implode( '/', $parameters );
 		} else {

--- a/includes/class-wcpdf-frontend.php
+++ b/includes/class-wcpdf-frontend.php
@@ -82,7 +82,7 @@ class Frontend {
 
 					if ( function_exists( 'file_get_contents' ) && $script = file_get_contents( WPO_WCPDF()->plugin_path() . '/assets/js/my-account-link'.$suffix.'.js' ) ) {
 
-						if ( WPO_WCPDF()->endpoint->is_enabled() ) {
+						if ( WPO_WCPDF()->endpoint->pretty_links_enabled() ) {
 							$script = str_replace( 'generate_wpo_wcpdf', WPO_WCPDF()->endpoint->get_identifier(), $script );
 						}
 						

--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -465,8 +465,8 @@ class Install {
 		}
 		
 		
-		// 3.7.0-beta-1: deactivate legacy ubl addon and migrate settings
-		if ( version_compare( $installed_version, '3.7.0-beta-1', '<' ) ) {
+		// 3.7.0-beta-4: deactivate legacy ubl addon and migrate settings
+		if ( version_compare( $installed_version, '3.7.0-beta-4', '<' ) ) {
 			// deactivate legacy ubl addon
 			WPO_WCPDF()->deactivate_ubl_addon();
 			
@@ -527,6 +527,11 @@ class Install {
 			$legacy_ubl_tax_setings = get_option( 'ubl_wc_taxes', [] );
 			if ( ! empty( $legacy_ubl_tax_setings ) ) {
 				update_option( 'wpo_wcpdf_settings_ubl_taxes', $legacy_ubl_tax_setings );
+			}
+			
+			// set transient to flush rewrite rules if pretty links are enabled
+			if ( WPO_WCPDF()->endpoint->pretty_links_enabled() ) {
+				set_transient( 'wpo_wcpdf_flush_rewrite_rules', 'yes', HOUR_IN_SECONDS );
 			}
 		}
 		

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -286,7 +286,7 @@ class Settings {
 						}
 
 						// validate option values
-						$form_settings = WPO_WCPDF()->settings->callbacks->validate( $form_settings );
+						$form_settings = $this->callbacks->validate( $form_settings );
 
 						// filter the options
 						add_filter( "option_{$option_key}", function( $value, $option ) use ( $form_settings ) {
@@ -306,7 +306,7 @@ class Settings {
 				if ( $document ) {
 					if ( ! $document->exists() ) {
 						$document->set_date( current_time( 'timestamp', true ) );
-						$number_store_method = WPO_WCPDF()->settings->get_sequential_number_store_method();
+						$number_store_method = $this->get_sequential_number_store_method();
 						$number_store_name   = apply_filters( 'wpo_wcpdf_document_sequential_number_store', "{$document->slug}_number", $document );
 						$number_store        = new Sequential_Number_Store( $number_store_name, $number_store_method );
 						$document->set_number( $number_store->get_next() );
@@ -526,20 +526,23 @@ class Settings {
 	}
 
 	public function get_output_format( $document = null ) {
+		$output_format = 'pdf'; // default
+		
 		if ( isset( $this->debug_settings['html_output'] ) || ( isset( $_REQUEST['output'] ) && 'html' === $_REQUEST['output'] ) ) {
 			$output_format = 'html';
 		} elseif ( isset( $_REQUEST['output'] ) && ! empty( $_REQUEST['output'] ) && ! empty( $document ) && in_array( $_REQUEST['output'], $document->output_formats ) ) {
-			$output_format = sanitize_text_field( $_REQUEST['output'] );
-		} else {
-			$output_format = 'pdf';
+			$document_settings = $this->get_document_settings( $document->get_type(), esc_attr( $_REQUEST['output'] ) );
+			if ( isset( $document_settings['enabled'] ) ) {
+				$output_format = esc_attr( $_REQUEST['output'] );
+			}
 		}
 		
 		return apply_filters( 'wpo_wcpdf_output_format', $output_format, $document );
 	}
 
 	public function get_output_mode() {
-		if ( isset( WPO_WCPDF()->settings->general_settings['download_display'] ) ) {
-			switch ( WPO_WCPDF()->settings->general_settings['download_display'] ) {
+		if ( isset( $this->general_settings['download_display'] ) ) {
+			switch ( $this->general_settings['download_display'] ) {
 				case 'display':
 					$output_mode = 'inline';
 					break;

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -950,7 +950,7 @@ abstract class Order_Document {
 		$pdf = $this->get_pdf();
 		wcpdf_pdf_headers( $this->get_filename(), $output_mode, $pdf );
 		echo $pdf;
-		wp_die();
+		exit();
 	}
 
 	public function output_html() {

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -971,15 +971,17 @@ abstract class Order_Document {
 			$ubl_document->set_order_document( $order_document );
 		} else {
 			wcpdf_log_error( 'Error generating order document for UBL!', 'error' );
-			wp_die();
+			exit();
 		}
 
 		$builder       = new SabreBuilder();
 		$contents      = $builder->build( $ubl_document );
+		
 		if ( $contents_only ) {
 			return $contents;
 		}
-		$filename      = $order_document->get_filename( 'download', [ 'output' => 'ubl' ] );
+		
+		$filename      = $order_document->get_filename( 'download', array( 'output' => 'ubl' ) );
 		$full_filename = $ubl_maker->write( $filename, $contents );
 		$quoted        = sprintf( '"%s"', addcslashes( basename( $full_filename ), '"\\' ) );
 		$size          = filesize( $full_filename );
@@ -991,7 +993,7 @@ abstract class Order_Document {
 		@readfile( $full_filename );
 		@unlink( $full_filename );
 
-		wp_die();
+		exit();
 	}
 
 	public function wrap_html_content( $content ) {

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -974,8 +974,8 @@ abstract class Order_Document {
 			exit();
 		}
 
-		$builder       = new SabreBuilder();
-		$contents      = $builder->build( $ubl_document );
+		$builder  = new SabreBuilder();
+		$contents = $builder->build( $ubl_document );
 		
 		if ( $contents_only ) {
 			return $contents;

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -955,7 +955,6 @@ abstract class Order_Document {
 
 	public function output_html() {
 		echo $this->get_html();
-		wp_die();
 	}
 	
 	public function preview_ubl() {

--- a/includes/wcpdf-functions.php
+++ b/includes/wcpdf-functions.php
@@ -201,14 +201,14 @@ function wcpdf_pdf_headers( $filename, $mode = 'inline', $pdf = null ) {
 }
 
 function wcpdf_ubl_headers( $filename, $size ) {
-	header( 'Content-Description: File Transfer ');
-	header( 'Content-Type: application/xml ');
+	header( 'Content-Description: File Transfer' );
+	header( 'Content-Type: text/xml' );
 	header( 'Content-Disposition: attachment; filename=' . $filename );
-	header( 'Content-Transfer-Encoding: binary ');
-	header( 'Connection: Keep-Alive ');
-	header( 'Expires: 0 ');
-	header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0 ');
-	header( 'Pragma: public ');
+	header( 'Content-Transfer-Encoding: binary' );
+	header( 'Connection: Keep-Alive' );
+	header( 'Expires: 0' );
+	header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
+	header( 'Pragma: public' );
 	header( 'Content-Length: ' . $size );
 	do_action( 'wpo_after_ubl_headers', $filename, $size );
 }


### PR DESCRIPTION
closes #620 

This PR fixes an issue when trying to output the document as HTML using pretty links.

This PR also improves the pretty link to include the output at the end:

- PDF render: `.../wcpdf/invoice/575/e28f82db34/pdf`
- HTML render: `.../wcpdf/invoice/575/e28f82db34/html`
- UBL download: `.../wcpdf/invoice/575/e28f82db34/ubl`
- The default link still uses: `&output=html`