### PR TITLE
Remove `target="_blank"` from UBL settings links

### DIFF
--- a/includes/settings/class-wcpdf-settings-ubl.php
+++ b/includes/settings/class-wcpdf-settings-ubl.php
@@ -150,8 +150,8 @@ class Settings_UBL {
 			$message = sprintf(
 				/* translators: 1. General Settings, 2. UBL Settings  */
 				__( 'You\'ve enabled UBL output for a document, but some essential details are missing. Please ensure you\'ve added your VAT and CoC numbers in the %1$s. Also, specify your tax rates in the %2$s.', 'woocommerce-pdf-invoices-packing-slips' ),
-				'<a href="' . esc_url( admin_url( 'admin.php?page=wpo_wcpdf_options_page' ) ) . '" target="_blank">' . __( 'General settings', 'woocommerce-pdf-invoices-packing-slips' ) . '</a>',
-				'<a href="' . esc_url( admin_url( 'admin.php?page=wpo_wcpdf_options_page&tab=ubl' ) ) . '" target="_blank">' . __( 'UBL settings', 'woocommerce-pdf-invoices-packing-slips' ) . '</a>'
+				'<a href="' . esc_url( admin_url( 'admin.php?page=wpo_wcpdf_options_page' ) ) . '">' . __( 'General settings', 'woocommerce-pdf-invoices-packing-slips' ) . '</a>',
+				'<a href="' . esc_url( admin_url( 'admin.php?page=wpo_wcpdf_options_page&tab=ubl' ) ) . '">' . __( 'UBL settings', 'woocommerce-pdf-invoices-packing-slips' ) . '</a>'
 			);
 			
 			echo '<div class="notice notice-warning"><p>' . $message . '</p></div>';


### PR DESCRIPTION
Since these settings are in the same context, that is the WP dashboard, it does not have much sense to open a new tab for these specific links.