### PR TITLE
Fix: bug on document variable name on `output_ubl` method

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -986,7 +986,7 @@ abstract class Order_Document {
 			return $contents;
 		}
 		
-		$filename      = $order_document->get_filename( 'download', array( 'output' => 'ubl' ) );
+		$filename      = $document->get_filename( 'download', array( 'output' => 'ubl' ) );
 		$full_filename = $ubl_maker->write( $filename, $contents );
 		$quoted        = sprintf( '"%s"', addcslashes( basename( $full_filename ), '"\\' ) );
 		$size          = filesize( $full_filename );


### PR DESCRIPTION
closes #634

Fixes bug introduced on this PR https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/pull/632