### PR TITLE
Tweak: improves the templates number/date functions

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1167,7 +1167,7 @@ abstract class Order_Document_Methods extends Order_Document {
 	public function get_invoice_number() {
 		wcpdf_log_error( 'The method get_invoice_number() is deprecated since version 3.7.3, please use the method get_number() instead.' );
 		
-		if ( is_callable( array( $this, 'get_formatted_number' ) ) ) {
+		if ( is_callable( array( $this, 'get_number' ) ) ) {
 			return $this->get_number( 'invoice', null, 'view', true );
 		} else {
 			return '';
@@ -1195,7 +1195,7 @@ abstract class Order_Document_Methods extends Order_Document {
 	public function get_invoice_date() {
 		wcpdf_log_error( 'The method get_invoice_date() is deprecated since version 3.7.3, please use the method get_date() instead.' );
 		
-		if ( is_callable( array( $this, 'get_formatted_date' ) ) ) {
+		if ( is_callable( array( $this, 'get_date' ) ) ) {
 			return $this->get_date( 'invoice', null, 'view', true );
 		} else {
 			return '';

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1160,6 +1160,10 @@ abstract class Order_Document_Methods extends Order_Document {
 		return $item_price;
 	}
 
+	/**
+	 * Legacy function (v3.7.2 or inferior)
+	 * Use $this->get_number() or $this->get_formatted_number() instead.
+	 */
 	public function get_invoice_number() {
 		// Call the woocommerce_invoice_number filter and let third-party plugins set a number.
 		// Default is null, so we can detect whether a plugin has set the invoice number
@@ -1175,10 +1179,18 @@ abstract class Order_Document_Methods extends Order_Document {
 		}
 	}
 
+	/**
+	 * Legacy function (v3.7.2 or inferior)
+	 * Use $this->number( 'invoice' ) instead.
+	 */
 	public function invoice_number() {
 		echo $this->get_invoice_number();
 	}
 
+	/**
+	 * Legacy function (v3.7.2 or inferior)
+	 * Use $this->get_date() or $this->get_formatted_date() instead.
+	 */
 	public function get_invoice_date() {
 		if ( $invoice_date = $this->get_date('invoice') ) {
 			return $invoice_date->date_i18n( wcpdf_date_format( $this, 'invoice_date' ) );
@@ -1187,6 +1199,10 @@ abstract class Order_Document_Methods extends Order_Document {
 		}
 	}
 
+	/**
+	 * Legacy function (v3.7.2 or inferior)
+	 * Use $this->date( 'invoice' ) instead.
+	 */
 	public function invoice_date() {
 		echo $this->get_invoice_date();
 	}

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1162,18 +1162,13 @@ abstract class Order_Document_Methods extends Order_Document {
 
 	/**
 	 * Legacy function (v3.7.2 or inferior)
-	 * Use $this->get_number() or $this->get_formatted_number() instead.
+	 * Use $this->get_formatted_number() instead.
 	 */
 	public function get_invoice_number() {
-		// Call the woocommerce_invoice_number filter and let third-party plugins set a number.
-		// Default is null, so we can detect whether a plugin has set the invoice number
-		$third_party_invoice_number = apply_filters( 'woocommerce_invoice_number', null, $this->order_id );
-		if ($third_party_invoice_number !== null) {
-			return $third_party_invoice_number;
-		}
-
-		if ( $invoice_number = $this->get_number('invoice') ) {
-			return $formatted_invoice_number = $invoice_number->get_formatted();
+		wcpdf_log_error( 'The method get_invoice_number() is deprecated since version 3.7.3, please use the method get_formatted_number() instead.' );
+		
+		if ( is_callable( array( $this, 'get_formatted_number' ) ) ) {
+			return $this->get_formatted_number( 'invoice' );
 		} else {
 			return '';
 		}
@@ -1184,16 +1179,24 @@ abstract class Order_Document_Methods extends Order_Document {
 	 * Use $this->number( 'invoice' ) instead.
 	 */
 	public function invoice_number() {
-		echo $this->get_invoice_number();
+		wcpdf_log_error( 'The method invoice_number() is deprecated since version 3.7.3, please use the method number() instead.' );
+		
+		if ( is_callable( array( $this, 'number' ) ) ) {
+			$this->number( 'invoice' );
+		} else {
+			echo '';
+		}
 	}
 
 	/**
 	 * Legacy function (v3.7.2 or inferior)
-	 * Use $this->get_date() or $this->get_formatted_date() instead.
+	 * Use $this->get_formatted_date() instead.
 	 */
 	public function get_invoice_date() {
-		if ( $invoice_date = $this->get_date('invoice') ) {
-			return $invoice_date->date_i18n( wcpdf_date_format( $this, 'invoice_date' ) );
+		wcpdf_log_error( 'The method get_invoice_date() is deprecated since version 3.7.3, please use the method get_formatted_date() instead.' );
+		
+		if ( is_callable( array( $this, 'get_formatted_date' ) ) ) {
+			return $this->get_formatted_date( 'invoice' );
 		} else {
 			return '';
 		}
@@ -1204,7 +1207,13 @@ abstract class Order_Document_Methods extends Order_Document {
 	 * Use $this->date( 'invoice' ) instead.
 	 */
 	public function invoice_date() {
-		echo $this->get_invoice_date();
+		wcpdf_log_error( 'The method invoice_date() is deprecated since version 3.7.3, please use the method date() instead.' );
+		
+		if ( is_callable( array( $this, 'date' ) ) ) {
+			$this->date( 'invoice' );
+		} else {
+			echo '';
+		}
 	}
 
 	public function get_document_notes() {

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -1162,13 +1162,13 @@ abstract class Order_Document_Methods extends Order_Document {
 
 	/**
 	 * Legacy function (v3.7.2 or inferior)
-	 * Use $this->get_formatted_number() instead.
+	 * Use $this->get_number() instead.
 	 */
 	public function get_invoice_number() {
-		wcpdf_log_error( 'The method get_invoice_number() is deprecated since version 3.7.3, please use the method get_formatted_number() instead.' );
+		wcpdf_log_error( 'The method get_invoice_number() is deprecated since version 3.7.3, please use the method get_number() instead.' );
 		
 		if ( is_callable( array( $this, 'get_formatted_number' ) ) ) {
-			return $this->get_formatted_number( 'invoice' );
+			return $this->get_number( 'invoice', null, 'view', true );
 		} else {
 			return '';
 		}
@@ -1190,13 +1190,13 @@ abstract class Order_Document_Methods extends Order_Document {
 
 	/**
 	 * Legacy function (v3.7.2 or inferior)
-	 * Use $this->get_formatted_date() instead.
+	 * Use $this->get_date() instead.
 	 */
 	public function get_invoice_date() {
-		wcpdf_log_error( 'The method get_invoice_date() is deprecated since version 3.7.3, please use the method get_formatted_date() instead.' );
+		wcpdf_log_error( 'The method get_invoice_date() is deprecated since version 3.7.3, please use the method get_date() instead.' );
 		
 		if ( is_callable( array( $this, 'get_formatted_date' ) ) ) {
-			return $this->get_formatted_date( 'invoice' );
+			return $this->get_date( 'invoice', null, 'view', true );
 		} else {
 			return '';
 		}

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -491,40 +491,32 @@ abstract class Order_Document {
 		return $value;
 	}
 
-	public function get_number( $document_type = '', $order = null, $context = 'view'  ) {
-		return $this->get_data( 'number', $document_type, $order, $context );
-	}
-	
-	public function get_formatted_number( $document_type ) {
-		$number = $this->get_number( $document_type );
+	public function get_number( $document_type = '', $order = null, $context = 'view', $formatted = false ) {
+		$number = $this->get_data( 'number', $document_type, $order, $context );
 		
-		if ( $number ) {
-			return $number->get_formatted();
-		} else {
-			return '';
+		if ( $number && $formatted ) {
+			$number = $number->get_formatted();
 		}
+		
+		return apply_filters( "wpo_wcpdf_{$this->slug}_number", $number, $document_type, $order, $context, $formatted, $this );
 	}
 
 	public function number( $document_type ) {
-		echo $this->get_formatted_number( $document_type );
+		echo $this->get_number( $document_type, null, 'view', true );
 	}
 
-	public function get_date( $document_type = '', $order = null, $context = 'view'  ) {
-		return $this->get_data( 'date', $document_type, $order, $context );
-	}
-	
-	public function get_formatted_date( $document_type ) {
-		$date = $this->get_date( $document_type );
+	public function get_date( $document_type = '', $order = null, $context = 'view', $formatted = false ) {		
+		$date = $this->get_data( 'date', $document_type, $order, $context );
 		
-		if ( $date ) {
-			return $date->date_i18n( wcpdf_date_format( $this, 'document_date' ) );
-		} else {
-			return '';
+		if ( $date && $formatted ) {
+			$date = $date->date_i18n( wcpdf_date_format( $this, 'document_date' ) );
 		}
+		
+		return apply_filters( "wpo_wcpdf_{$this->slug}_date", $date, $document_type, $order, $context, $formatted, $this );
 	}
 
 	public function date( $document_type ) {
-		echo $this->get_formatted_date( $document_type );
+		echo $this->get_date( $document_type, null, 'view', true );
 	}
 
 	public function get_notes( $document_type = '', $order = null, $context = 'view'  ) {
@@ -542,7 +534,7 @@ abstract class Order_Document {
 	public function get_title() {
 		return apply_filters( "wpo_wcpdf_{$this->slug}_title", $this->title, $this );
 	}
-
+	
 	public function title() {
 		echo $this->get_title(); 
 	}

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -494,9 +494,37 @@ abstract class Order_Document {
 	public function get_number( $document_type = '', $order = null, $context = 'view'  ) {
 		return $this->get_data( 'number', $document_type, $order, $context );
 	}
+	
+	public function get_formatted_number( $document_type ) {
+		$number = $this->get_number( $document_type );
+		
+		if ( $number ) {
+			return $number->get_formatted();
+		} else {
+			return '';
+		}
+	}
+
+	public function number( $document_type ) {
+		echo $this->get_formatted_number( $document_type );
+	}
 
 	public function get_date( $document_type = '', $order = null, $context = 'view'  ) {
 		return $this->get_data( 'date', $document_type, $order, $context );
+	}
+	
+	public function get_formatted_date( $document_type ) {
+		$date = $this->get_date( $document_type );
+		
+		if ( $date ) {
+			return $date->date_i18n( wcpdf_date_format( $this, 'document_date' ) );
+		} else {
+			return '';
+		}
+	}
+
+	public function date( $document_type ) {
+		echo $this->get_formatted_date( $document_type );
 	}
 
 	public function get_notes( $document_type = '', $order = null, $context = 'view'  ) {
@@ -524,11 +552,19 @@ abstract class Order_Document {
 		$number_title = sprintf( __( '%s Number:', 'woocommerce-pdf-invoices-packing-slips' ), $this->title );
 		return apply_filters( "wpo_wcpdf_{$this->slug}_number_title", $number_title, $this );
 	}
+	
+	public function number_title() {
+		echo $this->get_number_title(); 
+	}
 
 	public function get_date_title() {
 		/* translators: %s: document name */
 		$date_title = sprintf( __( '%s Date:', 'woocommerce-pdf-invoices-packing-slips' ), $this->title );
 		return apply_filters( "wpo_wcpdf_{$this->slug}_date_title", $date_title, $this );
+	}
+	
+	public function date_title() {
+		echo $this->get_date_title();
 	}
 
 	public function get_due_date_title() {

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -571,6 +571,10 @@ abstract class Order_Document {
 		$due_date_title = __( 'Due Date:', 'woocommerce-pdf-invoices-packing-slips' );
 		return apply_filters( "wpo_wcpdf_{$this->slug}_due_date_title", $due_date_title, $this );
 	}
+	
+	public function due_date_title() {
+		echo $this->get_due_date_title();
+	}
 
 	/*
 	|--------------------------------------------------------------------------

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -495,15 +495,7 @@ abstract class Order_Document {
 		return $this->get_data( 'number', $document_type, $order, $context );
 	}
 	
-	public function get_formatted_number( $document_type = null ) {
-		if ( empty( $document_type ) && is_callable( array( $this, 'get_type' ) ) ) {
-			$document_type = $this->get-type();
-			
-			if ( empty( $document_type ) ) {
-				return '';
-			}
-		}
-		
+	public function get_formatted_number( $document_type ) {
 		$number = $this->get_number( $document_type );
 		
 		if ( $number ) {
@@ -522,14 +514,6 @@ abstract class Order_Document {
 	}
 	
 	public function get_formatted_date( $document_type ) {
-		if ( empty( $document_type ) && is_callable( array( $this, 'get_type' ) ) ) {
-			$document_type = $this->get-type();
-			
-			if ( empty( $document_type ) ) {
-				return '';
-			}
-		}
-		
 		$date = $this->get_date( $document_type );
 		
 		if ( $date ) {

--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -495,7 +495,15 @@ abstract class Order_Document {
 		return $this->get_data( 'number', $document_type, $order, $context );
 	}
 	
-	public function get_formatted_number( $document_type ) {
+	public function get_formatted_number( $document_type = null ) {
+		if ( empty( $document_type ) && is_callable( array( $this, 'get_type' ) ) ) {
+			$document_type = $this->get-type();
+			
+			if ( empty( $document_type ) ) {
+				return '';
+			}
+		}
+		
 		$number = $this->get_number( $document_type );
 		
 		if ( $number ) {
@@ -514,6 +522,14 @@ abstract class Order_Document {
 	}
 	
 	public function get_formatted_date( $document_type ) {
+		if ( empty( $document_type ) && is_callable( array( $this, 'get_type' ) ) ) {
+			$document_type = $this->get-type();
+			
+			if ( empty( $document_type ) ) {
+				return '';
+			}
+		}
+		
 		$date = $this->get_date( $document_type );
 		
 		if ( $date ) {

--- a/templates/Simple/invoice.php
+++ b/templates/Simple/invoice.php
@@ -64,14 +64,14 @@
 				<?php do_action( 'wpo_wcpdf_before_order_data', $this->get_type(), $this->order ); ?>
 				<?php if ( isset( $this->settings['display_number'] ) ) : ?>
 					<tr class="invoice-number">
-						<th><?php echo $this->get_number_title(); ?></th>
-						<td><?php $this->invoice_number(); ?></td>
+						<th><?php $this->number_title(); ?></th>
+						<td><?php $this->number( $this->get_type() ); ?></td>
 					</tr>
 				<?php endif; ?>
 				<?php if ( isset( $this->settings['display_date'] ) ) : ?>
 					<tr class="invoice-date">
-						<th><?php echo $this->get_date_title(); ?></th>
-						<td><?php $this->invoice_date(); ?></td>
+						<th><?php $this->date_title(); ?></th>
+						<td><?php $this->date( $this->get_type() ); ?></td>
 					</tr>
 				<?php endif; ?>
 				<tr class="order-number">
@@ -82,10 +82,10 @@
 					<th><?php _e( 'Order Date:', 'woocommerce-pdf-invoices-packing-slips' ); ?></th>
 					<td><?php $this->order_date(); ?></td>
 				</tr>
-				<?php if ( $payment_method = $this->get_payment_method() ) : ?>
+				<?php if ( $this->get_payment_method() ) : ?>
 				<tr class="payment-method">
 					<th><?php _e( 'Payment Method:', 'woocommerce-pdf-invoices-packing-slips' ); ?></th>
-					<td><?php echo $payment_method; ?></td>
+					<td><?php $this->payment_method(); ?></td>
 				</tr>
 				<?php endif; ?>
 				<?php do_action( 'wpo_wcpdf_after_order_data', $this->get_type(), $this->order ); ?>


### PR DESCRIPTION
#659

This PR improves the templates display functions:

New functions:
```php
$this->number( $document_type );
$this->date( $document_type );
$this->number_title();
$this->date_title();
$this->due_date_title();
``` 

Deprecated functions:
`get_invoice_number`
`invoice_number`
`get_invoice_date`
`invoice_date`

Changed functions:
`get_number`: now includes `$formatted` `bool` arg
`get_date`: now includes `$formatted` `bool` arg