### PR TITLE
Disable packing slip attachment

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -133,6 +133,11 @@ class Main {
 		$attach_to_document_types = $this->get_documents_for_email( $email_id, $order );
 		foreach ( $attach_to_document_types as $output_format => $document_types ) {
 			foreach ( $document_types as $document_type ) {
+				//If Professional extension is not active, only attach the invoice
+				if ( ! function_exists( 'WPO_WCPDF_Pro' ) && $document_type !== 'invoice' ) {
+					return $attachments;
+				};
+				
 				$email_order    = apply_filters( 'wpo_wcpdf_email_attachment_order', $order, $email, $document_type );
 				$email_order_id = $email_order->get_id();
 


### PR DESCRIPTION
closes #644 

We recently found a 9 year old bug where the packing slips are attached to the emails in the free version, when only the invoices are attached to the emails in the free version. The bug is cause by a user enabling an option in the "Attach to" setting from the Professional extension. If the Professional extension is deactivated, that "Attach to" email setting is still saved and the packing slip is thus attached to the email.