### PR TITLE
Fix: Invoice number race condition

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -184,7 +184,7 @@ class Main {
 		if ( $lock->lock( $this->lock_retries ) ) {
 			
 			if ( $this->lock_log_enabled ) {
-				$lock->log( sprinf( 'Lock acquired for attach document to email for order ID# %s.', $order_id ), 'info' );
+				$lock->log( sprintf( 'Lock acquired for attach document to email for order ID# %s.', $order_id ), 'info' );
 			}
 		
 			foreach ( $attach_to_document_types as $output_format => $document_types ) {
@@ -258,12 +258,12 @@ class Main {
 			$lock_release = $lock->release();
 			
 			if ( $lock_release && $this->lock_log_enabled ) {
-				$lock->log( sprinf( 'Lock released for attach document to email for order ID# %s.', $order_id ), 'info' );
+				$lock->log( sprintf( 'Lock released for attach document to email for order ID# %s.', $order_id ), 'info' );
 			}
 		
 		} else {
 			if ( $this->lock_log_enabled ) {
-				$lock->log( sprinf( 'Couldn\'t get the lock for attach document to email for order ID# %s.', $order_id ), 'critical' );
+				$lock->log( sprintf( 'Couldn\'t get the lock for attach document to email for order ID# %s.', $order_id ), 'critical' );
 			}
 		}
 

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -33,7 +33,7 @@ class Main {
 		// semaphore
 		$this->lock_name    = 'wpo_wcpdf_main_lock';
 		$this->lock_context = array( 'source' => 'wpo-wcpdf-main' );
-		$this->lock_time    = apply_filters( 'wpo_wcpdf_main_lock_time', 300 );
+		$this->lock_time    = apply_filters( 'wpo_wcpdf_main_lock_time', 60 );
 		$this->lock_retries = apply_filters( 'wpo_wcpdf_main_lock_retries', 0 );
 		
 		add_action( 'wp_ajax_generate_wpo_wcpdf', array( $this, 'generate_document_ajax' ) );

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -42,6 +42,13 @@ class Main {
 	public $lock_retries;
 	
 	/**
+	 * Lock loggers
+	 *
+	 * @var int
+	 */
+	public $lock_loggers;
+	
+	/**
 	 * Temp subfolders
 	 *
 	 * @var array
@@ -59,10 +66,11 @@ class Main {
 
 	public function __construct() {
 		// semaphore
-		$this->lock_name        = 'wpo_wcpdf_main_semaphore_lock';
-		$this->lock_context     = array( 'source' => 'wpo-wcpdf-semaphore' );
-		$this->lock_time        = apply_filters( 'wpo_wcpdf_main_semaphore_lock_time', 60 );
-		$this->lock_retries     = apply_filters( 'wpo_wcpdf_main_semaphore_lock_retries', 0 );
+		$this->lock_name    = 'wpo_wcpdf_main_semaphore_lock';
+		$this->lock_context = array( 'source' => 'wpo-wcpdf-semaphore' );
+		$this->lock_time    = apply_filters( 'wpo_wcpdf_main_semaphore_lock_time', 60 );
+		$this->lock_retries = apply_filters( 'wpo_wcpdf_main_semaphore_lock_retries', 0 );
+		$this->lock_loggers = apply_filters( 'wpo_wcpdf_main_semaphore_lock_loggers', isset( WPO_WCPDF()->settings->debug_settings['semaphore_logs'] ) ? array( wc_get_logger() ) : array() );
 		
 		add_action( 'wp_ajax_generate_wpo_wcpdf', array( $this, 'generate_document_ajax' ) );
 		add_action( 'wp_ajax_nopriv_generate_wpo_wcpdf', array( $this, 'generate_document_ajax' ) );
@@ -171,7 +179,7 @@ class Main {
 		}
 
 		$attach_to_document_types = $this->get_documents_for_email( $email_id, $order );
-		$lock                     = new Semaphore( $this->lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
+		$lock                     = new Semaphore( $this->lock_name, $this->lock_time, $this->lock_loggers, $this->lock_context );
 		
 		if ( $lock->lock( $this->lock_retries ) ) {
 			

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -143,8 +143,7 @@ class Main {
 		}
 
 		$attach_to_document_types = $this->get_documents_for_email( $email_id, $order );
-		$lock_name                = $this->lock_name . '_attach_document_to_email_' . $order_id;
-		$lock                     = new Semaphore( $lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
+		$lock                     = new Semaphore( $this->lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
 		
 		foreach ( $attach_to_document_types as $output_format => $document_types ) {
 			foreach ( $document_types as $document_type ) {

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -42,13 +42,6 @@ class Main {
 	public $lock_retries;
 	
 	/**
-	 * If the lock log is enabled
-	 *
-	 * @var int
-	 */
-	public $lock_log_enabled;
-	
-	/**
 	 * Temp subfolders
 	 *
 	 * @var array
@@ -70,7 +63,6 @@ class Main {
 		$this->lock_context     = array( 'source' => 'wpo-wcpdf-semaphore' );
 		$this->lock_time        = apply_filters( 'wpo_wcpdf_main_semaphore_lock_time', 60 );
 		$this->lock_retries     = apply_filters( 'wpo_wcpdf_main_semaphore_lock_retries', 0 );
-		$this->lock_log_enabled = isset( WPO_WCPDF()->settings->debug_settings['semaphore_logs'] ) ? true : false;
 		
 		add_action( 'wp_ajax_generate_wpo_wcpdf', array( $this, 'generate_document_ajax' ) );
 		add_action( 'wp_ajax_nopriv_generate_wpo_wcpdf', array( $this, 'generate_document_ajax' ) );
@@ -183,9 +175,7 @@ class Main {
 		
 		if ( $lock->lock( $this->lock_retries ) ) {
 			
-			if ( $this->lock_log_enabled ) {
-				$lock->log( sprintf( 'Lock acquired for attach document to email for order ID# %s.', $order_id ), 'info' );
-			}
+			$lock->log( sprintf( 'Lock acquired for attach document to email for order ID# %s.', $order_id ), 'info' );
 		
 			foreach ( $attach_to_document_types as $output_format => $document_types ) {
 				foreach ( $document_types as $document_type ) {
@@ -255,16 +245,12 @@ class Main {
 				}
 			}
 			
-			$lock_release = $lock->release();
-			
-			if ( $lock_release && $this->lock_log_enabled ) {
+			if ( $lock->release() ) {
 				$lock->log( sprintf( 'Lock released for attach document to email for order ID# %s.', $order_id ), 'info' );
 			}
 		
 		} else {
-			if ( $this->lock_log_enabled ) {
-				$lock->log( sprintf( 'Couldn\'t get the lock for attach document to email for order ID# %s.', $order_id ), 'critical' );
-			}
+			$lock->log( sprintf( 'Couldn\'t get the lock for attach document to email for order ID# %s.', $order_id ), 'critical' );
 		}
 
 		remove_filter( 'wcpdf_disable_deprecation_notices', '__return_true' );

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -246,7 +246,7 @@ class Main {
 			$lock->release();
 		
 		} else {
-			$lock->log( sprintf( 'Couldn\'t get the lock for the order ID# %s!', $email_order_id ), 'critical' );
+			$lock->log( sprintf( 'Couldn\'t get the lock for the order ID# %s!', $order_id ), 'critical' );
 		}
 
 		remove_filter( 'wcpdf_disable_deprecation_notices', '__return_true' );

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -143,7 +143,8 @@ class Main {
 		}
 
 		$attach_to_document_types = $this->get_documents_for_email( $email_id, $order );
-		$lock                     = new Semaphore( $this->lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
+		$lock_name                = $this->lock_name . '_attach_document_to_email_' . $order_id;
+		$lock                     = new Semaphore( $lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
 		
 		foreach ( $attach_to_document_types as $output_format => $document_types ) {
 			foreach ( $document_types as $document_type ) {

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -13,11 +13,39 @@ if ( ! class_exists( '\\WPO\\WC\\PDF_Invoices\\Main' ) ) :
 
 class Main {
 
+	/**
+	 * Lock name
+	 *
+	 * @var string
+	 */
 	public $lock_name;
+	
+	/**
+	 * Lock context
+	 *
+	 * @var array
+	 */
 	public $lock_context;
+	
+	/**
+	 * Lock time limit if the release doesn't happen before
+	 *
+	 * @var int
+	 */
 	public $lock_time;
+	
+	/**
+	 * Lock retries
+	 *
+	 * @var int
+	 */
 	public $lock_retries;
 	
+	/**
+	 * Temp subfolders
+	 *
+	 * @var array
+	 */
 	private $subfolders = array( 'attachments', 'fonts', 'dompdf' );
 	
 	protected static $_instance = null;

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -246,7 +246,7 @@ class Main {
 			$lock->release();
 		
 		} else {
-			$lock->log( sprintf( 'Couldn\'t get the %1$s attachment lock for the email ID# %2$s from the order ID# %3$s!', $document_type, $email_id, $email_order_id ), 'critical' );
+			$lock->log( sprintf( 'Couldn\'t get the lock for the order ID# %s!', $email_order_id ), 'critical' );
 		}
 
 		remove_filter( 'wcpdf_disable_deprecation_notices', '__return_true' );

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -53,7 +53,7 @@ class Settings {
 		
 		$this->lock_name        = 'wpo_wcpdf_settings_lock';
 		$this->lock_context     = array( 'source' => 'wpo-wcpdf-settings' );
-		$this->lock_time        = apply_filters( 'wpo_wcpdf_settings_lock_time', 300 );
+		$this->lock_time        = apply_filters( 'wpo_wcpdf_settings_lock_time', 60 );
 		$this->lock_retries     = apply_filters( 'wpo_wcpdf_settings_lock_retries', 0 );
 
 		// Settings menu item

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -51,10 +51,10 @@ class Settings {
 		$this->debug_settings   = get_option( 'wpo_wcpdf_settings_debug' );
 		$this->ubl_tax_settings = get_option( 'wpo_wcpdf_settings_ubl_taxes' );
 		
-		$this->lock_name        = 'wpo_wcpdf_semaphore_lock';
-		$this->lock_context     = array( 'source' => 'wpo-wcpdf-semaphore' );
-		$this->lock_time        = apply_filters( 'wpo_wcpdf_semaphore_lock_time', 2 );
-		$this->lock_retries     = apply_filters( 'wpo_wcpdf_semaphore_lock_retries', 0 );
+		$this->lock_name        = 'wpo_wcpdf_settings_lock';
+		$this->lock_context     = array( 'source' => 'wpo-wcpdf-settings' );
+		$this->lock_time        = apply_filters( 'wpo_wcpdf_settings_lock_time', 300 );
+		$this->lock_retries     = apply_filters( 'wpo_wcpdf_settings_lock_retries', 0 );
 
 		// Settings menu item
 		add_action( 'admin_menu', array( $this, 'menu' ), 999 ); // Add menu

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -26,7 +26,6 @@ class Settings {
 	public $lock_context;
 	public $lock_time;
 	public $lock_retries;
-	public $lock_log_enabled;
 	private $installed_templates       = array();
 	private $installed_templates_cache = array();
 	private $template_list_cache       = array();
@@ -56,7 +55,6 @@ class Settings {
 		$this->lock_context     = array( 'source' => 'wpo-wcpdf-semaphore' );
 		$this->lock_time        = apply_filters( 'wpo_wcpdf_settings_semaphore_lock_time', 60 );
 		$this->lock_retries     = apply_filters( 'wpo_wcpdf_settings_semaphore_lock_retries', 0 );
-		$this->lock_log_enabled = isset( $this->debug_settings['semaphore_logs'] ) ? true : false;
 
 		// Settings menu item
 		add_action( 'admin_menu', array( $this, 'menu' ), 999 ); // Add menu
@@ -815,9 +813,7 @@ class Settings {
 			
 			if ( $lock->lock( $this->lock_retries ) ) {
 				
-				if ( $this->lock_log_enabled ) {
-					$lock->log( 'Lock acquired for yearly reset numbers schedule.', 'info' );
-				}
+				$lock->log( 'Lock acquired for yearly reset numbers schedule.', 'info' );
 				
 				try {
 					$action_id = as_schedule_single_action( $datetime->getTimestamp(), $hook );
@@ -837,17 +833,13 @@ class Settings {
 				} catch ( \Error $e ) {
 					$lock->log( $e, 'critical' );
 				}
-	
-				$lock_release = $lock->release();
 				
-				if ( $lock_release && $this->lock_log_enabled ) {
+				if ( $lock->release() ) {
 					$lock->log( 'Lock released for yearly reset numbers schedule.', 'info' );
 				}
 				
 			} else {
-				if ( $this->lock_log_enabled ) {
-					$lock->log( 'Couldn\'t get the lock for yearly reset numbers schedule.', 'critical' );
-				}
+				$lock->log( 'Couldn\'t get the lock for yearly reset numbers schedule.', 'critical' );
 			}
 			
 		} else {
@@ -870,9 +862,7 @@ class Settings {
 
 		if ( $lock->lock( $this->lock_retries ) ) {
 			
-			if ( $this->lock_log_enabled ) {
-				$lock->log( 'Lock acquired for yearly reset numbers.', 'info' );
-			}
+			$lock->log( 'Lock acquired for yearly reset numbers.', 'info' );
 			
 			try {
 				// reset numbers
@@ -905,17 +895,13 @@ class Settings {
 			} catch ( \Error $e ) {
 				$lock->log( $e, 'critical' );
 			}
-
-			$lock_release = $lock->release();
 			
-			if ( $lock_release && $this->lock_log_enabled ) {
+			if ( $lock->release() ) {
 				$lock->log( 'Lock release for yearly reset numbers.', 'info' );
 			}
 			
 		} else {
-			if ( $this->lock_log_enabled ) {
-				$lock->log( 'Couldn\'t get the lock for yearly reset numbers.', 'critical' );
-			}
+			$lock->log( 'Couldn\'t get the lock for yearly reset numbers.', 'critical' );
 		}
 		
 		// reschedule the action for the next year

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -26,6 +26,8 @@ class Settings {
 	public $lock_context;
 	public $lock_time;
 	public $lock_retries;
+	public $lock_loggers;
+	
 	private $installed_templates       = array();
 	private $installed_templates_cache = array();
 	private $template_list_cache       = array();
@@ -55,6 +57,7 @@ class Settings {
 		$this->lock_context     = array( 'source' => 'wpo-wcpdf-semaphore' );
 		$this->lock_time        = apply_filters( 'wpo_wcpdf_settings_semaphore_lock_time', 60 );
 		$this->lock_retries     = apply_filters( 'wpo_wcpdf_settings_semaphore_lock_retries', 0 );
+		$this->lock_loggers     = apply_filters( 'wpo_wcpdf_settings_semaphore_lock_loggers', isset( $this->debug_settings['semaphore_logs'] ) ? array( wc_get_logger() ) : array() );
 
 		// Settings menu item
 		add_action( 'admin_menu', array( $this, 'menu' ), 999 ); // Add menu
@@ -799,7 +802,7 @@ class Settings {
 		
 		$next_year = strval( intval( current_time( 'Y' ) ) + 1 );
 		$datetime  = new \WC_DateTime( "{$next_year}-01-01 00:00:01", new \DateTimeZone( wc_timezone_string() ) );
-		$lock      = new Semaphore( $this->lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
+		$lock      = new Semaphore( $this->lock_name, $this->lock_time, $this->lock_loggers, $this->lock_context );
 		$hook      = 'wpo_wcpdf_schedule_yearly_reset_numbers';
 		
 		// checks if there are pending actions
@@ -858,7 +861,7 @@ class Settings {
 	}
 
 	public function yearly_reset_numbers() {
-		$lock = new Semaphore( $this->lock_name, $this->lock_time, array( wc_get_logger() ), $this->lock_context );
+		$lock = new Semaphore( $this->lock_name, $this->lock_time, $this->lock_loggers, $this->lock_context );
 
 		if ( $lock->lock( $this->lock_retries ) ) {
 			

--- a/includes/class-wcpdf-updraft-semaphore.php
+++ b/includes/class-wcpdf-updraft-semaphore.php
@@ -193,7 +193,8 @@ class Updraft_Semaphore_3_0 {
 	 */
 	public function log( $message, $level = 'info', $context = array() ) {
 		$context = ! empty( $context ) ? $context : $this->context;
-		if ( isset( $this->loggers ) && isset( WPO_WCPDF()->settings->debug_settings['semaphore_logs'] ) ) {
+		
+		if ( ! empty( $this->loggers ) ) {
 			foreach ( $this->loggers as $logger ) {
 				if ( ! empty( $context ) ) {
 					$logger->log( $level, $message, $context );

--- a/includes/class-wcpdf-updraft-semaphore.php
+++ b/includes/class-wcpdf-updraft-semaphore.php
@@ -193,7 +193,7 @@ class Updraft_Semaphore_3_0 {
 	 */
 	public function log( $message, $level = 'info', $context = array() ) {
 		$context = ! empty( $context ) ? $context : $this->context;
-		if ( isset( $this->loggers ) ) {
+		if ( isset( $this->loggers ) && isset( WPO_WCPDF()->settings->debug_settings['semaphore_logs'] ) ) {
 			foreach ( $this->loggers as $logger ) {
 				if ( ! empty( $context ) ) {
 					$logger->log( $level, $message, $context );

--- a/includes/documents/class-wcpdf-invoice.php
+++ b/includes/documents/class-wcpdf-invoice.php
@@ -38,7 +38,7 @@ class Invoice extends Order_Document_Methods {
 		// semaphore
 		$this->lock_name    = "wpo_wcpdf_{$this->slug}_number_lock";
 		$this->lock_context = array( 'source' => "wpo-wcpdf-{$this->type}-semaphore" );
-		$this->lock_time    = apply_filters( "wpo_wcpdf_{$this->type}_number_lock_time", 300 );
+		$this->lock_time    = apply_filters( "wpo_wcpdf_{$this->type}_number_lock_time", 60 );
 		$this->lock_retries = apply_filters( "wpo_wcpdf_{$this->type}_number_lock_retries", 0 );
 		
 		// call parent constructor

--- a/includes/settings/class-wcpdf-settings-debug.php
+++ b/includes/settings/class-wcpdf-settings-debug.php
@@ -768,6 +768,18 @@ class Settings_Debug {
 			),
 			array(
 				'type'     => 'setting',
+				'id'       => 'semaphore_logs',
+				'title'    => __( 'Enable semaphore logs', 'woocommerce-pdf-invoices-packing-slips' ),
+				'callback' => 'checkbox',
+				'section'  => 'debug_settings',
+				'args'     => array(
+					'option_name' => $option_name,
+					'id'          => 'semaphore_logs',
+					'description' => __( 'Our plugin uses a semaphore class that prevents race conditions in multiple places in the code. Enable this setting only if you are having issues with document numbers, yearly reset or documents being assigned to the wrong order.', 'woocommerce-pdf-invoices-packing-slips' ),
+				)
+			),
+			array(
+				'type'     => 'setting',
 				'id'       => 'enable_danger_zone_tools',
 				'title'    => __( 'Enable danger zone tools', 'woocommerce-pdf-invoices-packing-slips' ),
 				'callback' => 'checkbox',


### PR DESCRIPTION
closes #619 

This PR attempts to fix the race condition issue spotted using Stripe plugin.

It changes the lock time to `60` seconds, to avoid expiring before the code being finished, and now also adds a lock to the email attachment function as well, which is the primary way of getting duplicated numbers.