### PR TITLE
Fix a bug in "Full" document access

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -517,8 +517,8 @@ class Main {
 				}
 				break;
 			case 'full':
-				// check if we have a valid access key
-				if ( $order && ! hash_equals( $order->get_order_key(), $_REQUEST['access_key'] ) ) {
+				// check if we have a valid access key only when it's not from bulk actions
+				if ( ! isset( $_REQUEST['bulk'] ) && $order && ! hash_equals( $order->get_order_key(), $_REQUEST['access_key'] ) ) {
 					$allowed = false;
 					break;
 				}


### PR DESCRIPTION
When the access type is set to "Full," using bulk actions to generate an invoice for a single order results in a permission error. Still, it's working correctly if several orders have been chosen.