### PR TITLE
Tweak: includes `$args` in filter hook `wpo_wcpdf_filename` parameters

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document.php
+++ b/includes/documents/abstract-wcpdf-order-document.php
@@ -1086,7 +1086,7 @@ abstract class Order_Document {
 
 		// Filter filename
 		$order_ids = isset( $args['order_ids'] ) ? $args['order_ids'] : array( $this->order_id );
-		$filename  = apply_filters( 'wpo_wcpdf_filename', $filename, $this->get_type(), $order_ids, $context );
+		$filename  = apply_filters( 'wpo_wcpdf_filename', $filename, $this->get_type(), $order_ids, $context, $args );
 
 		// sanitize filename (after filters to prevent human errors)!
 		return sanitize_file_name( $filename );

--- a/includes/documents/class-wcpdf-invoice.php
+++ b/includes/documents/class-wcpdf-invoice.php
@@ -179,7 +179,7 @@ class Invoice extends Order_Document_Methods {
 
 		// Filter filename
 		$order_ids = isset( $args['order_ids'] ) ? $args['order_ids'] : array( $this->order_id );
-		$filename  = apply_filters( 'wpo_wcpdf_filename', $filename, $this->get_type(), $order_ids, $context );
+		$filename  = apply_filters( 'wpo_wcpdf_filename', $filename, $this->get_type(), $order_ids, $context, $args );
 
 		// sanitize filename (after filters to prevent human errors)!
 		return sanitize_file_name( $filename );

--- a/includes/documents/class-wcpdf-packing-slip.php
+++ b/includes/documents/class-wcpdf-packing-slip.php
@@ -62,7 +62,7 @@ class Packing_Slip extends Order_Document_Methods {
 
 		// Filter filename
 		$order_ids = isset( $args['order_ids'] ) ? $args['order_ids'] : array( $this->order_id );
-		$filename  = apply_filters( 'wpo_wcpdf_filename', $filename, $this->get_type(), $order_ids, $context );
+		$filename  = apply_filters( 'wpo_wcpdf_filename', $filename, $this->get_type(), $order_ids, $context, $args );
 
 		// sanitize filename (after filters to prevent human errors)!
 		return sanitize_file_name( $filename );


### PR DESCRIPTION
This new parameter is required to pass the `output` key, which can be `ubl`.