### PR TITLE
Fix a bug in `get_payment_date()`

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -475,7 +475,7 @@ abstract class Order_Document_Methods extends Order_Document {
 			$payment_date = $this->order->get_date_paid();
 		}
 
-		$payment_date = apply_filters( 'wpo_wcpdf_date', date_i18n( wcpdf_date_format( $this, 'order_date_paid' ), $payment_date->getTimestamp() ) );
+		$payment_date = empty( $payment_date ) ? null : apply_filters( 'wpo_wcpdf_date', date_i18n( wcpdf_date_format( $this, 'order_date_paid' ), $payment_date->getTimestamp() ) );
 
 		return apply_filters( 'wpo_wcpdf_payment_date', $payment_date, $this );
 	}


### PR DESCRIPTION
If there is no paid date for an order, the `get_date_paid()` returns null, and it can lead to this error:
`
Fatal error: Call to a member function getTimestamp() on null
C:\laragon\www\mohamad\wp-content\plugins\woocommerce-pdf-invoices-packing-slips\includes\documents\abstract-wcpdf-order-document-methods.php (478)
`