### PR TITLE
Declare new "Payment Date:" string

### DIFF
--- a/languages/strings.php
+++ b/languages/strings.php
@@ -2,6 +2,7 @@
 exit;
 __( 'VAT', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Tax rate', 'woocommerce-pdf-invoices-packing-slips' );
+__( 'Payment Date:', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Payment method', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Shipping method', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Send email', 'woocommerce-pdf-invoices-packing-slips' );

--- a/languages/strings.php
+++ b/languages/strings.php
@@ -2,7 +2,7 @@
 exit;
 __( 'VAT', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Tax rate', 'woocommerce-pdf-invoices-packing-slips' );
-__( 'Payment Date:', 'woocommerce-pdf-invoices-packing-slips' );
+__( 'Payment date', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Payment method', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Shipping method', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Send email', 'woocommerce-pdf-invoices-packing-slips' );


### PR DESCRIPTION
Currently, we are using the "Payment Date:" string within the Receipt document in both Professional and Premium Templates extensions, but it has not yet been declared within our free main plugin.