### PR TITLE
Declare new "Payment Date:" string (II)

### DIFF
--- a/languages/strings.php
+++ b/languages/strings.php
@@ -3,6 +3,7 @@ exit;
 __( 'VAT', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Tax rate', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Payment date', 'woocommerce-pdf-invoices-packing-slips' );
+__( 'Payment Date:', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Payment method', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Shipping method', 'woocommerce-pdf-invoices-packing-slips' );
 __( 'Send email', 'woocommerce-pdf-invoices-packing-slips' );


### PR DESCRIPTION
Currently, we are using the "Payment Date:" string within the Receipt document, but it has not yet been declared.

Related with #683.