### PR TITLE
New: hides the Upgrade tab on bundle. New extensions license cache system

### DIFF
--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -206,24 +206,10 @@ class Settings {
 		$default_tab    = apply_filters( 'wpo_wcpdf_settings_tabs_default', ! empty( $settings_tabs['general'] ) ? 'general' : key( $settings_tabs ) );
 		$active_tab     = isset( $_GET[ 'tab' ] ) ? sanitize_text_field( $_GET[ 'tab' ] ) : $default_tab;
 		$active_section = isset( $_GET[ 'section' ] ) ? sanitize_text_field( $_GET[ 'section' ] ) : '';
+		$bundle         = $this->upgrade ? $this->upgrade->bundle_is_active() : false;
 		
-		$extension_license_infos = $this->upgrade ? $this->upgrade->get_extension_license_infos() : array();
-		
-		if ( ! empty( $extension_license_infos ) ) {
-			$bundle = true;
-			foreach ( $this->upgrade->extensions as $extension ) {
-				if (
-					( isset( $extension_license_infos[ $extension ]['status'] ) && 'valid' !== $extension_license_infos[ $extension ]['status'] ) ||
-					! isset( $extension_license_infos[ $extension ]['status'] )
-				) {
-					$bundle = false;
-					break;
-				}
-			}
-			
-			if ( $bundle ) {
-				unset( $settings_tabs['upgrade'] );
-			}
+		if ( $bundle ) {
+			unset( $settings_tabs['upgrade'] );
 		}
 
 		include( 'views/settings-page.php' );

--- a/includes/class-wcpdf-settings.php
+++ b/includes/class-wcpdf-settings.php
@@ -206,6 +206,25 @@ class Settings {
 		$default_tab    = apply_filters( 'wpo_wcpdf_settings_tabs_default', ! empty( $settings_tabs['general'] ) ? 'general' : key( $settings_tabs ) );
 		$active_tab     = isset( $_GET[ 'tab' ] ) ? sanitize_text_field( $_GET[ 'tab' ] ) : $default_tab;
 		$active_section = isset( $_GET[ 'section' ] ) ? sanitize_text_field( $_GET[ 'section' ] ) : '';
+		
+		$extension_license_infos = $this->upgrade ? $this->upgrade->get_extension_license_infos() : array();
+		
+		if ( ! empty( $extension_license_infos ) ) {
+			$bundle = true;
+			foreach ( $this->upgrade->extensions as $extension ) {
+				if (
+					( isset( $extension_license_infos[ $extension ]['status'] ) && 'valid' !== $extension_license_infos[ $extension ]['status'] ) ||
+					! isset( $extension_license_infos[ $extension ]['status'] )
+				) {
+					$bundle = false;
+					break;
+				}
+			}
+			
+			if ( $bundle ) {
+				unset( $settings_tabs['upgrade'] );
+			}
+		}
 
 		include( 'views/settings-page.php' );
 	}

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -22,8 +22,21 @@ class Settings_Upgrade {
 	public function __construct() {
 		$this->extensions = array( 'pro', 'templates' );
 		
+		add_action( 'wpo_wcpdf_before_settings_page', array( $this, 'extensions_license_cache_notice' ), 10, 2 );
 		add_action( 'wpo_wcpdf_after_settings_page', array( $this, 'extension_overview' ), 10, 2 );
 		add_action( 'wpo_wcpdf_schedule_extensions_license_cache_clearing', array( $this, 'clear_extensions_license_cache' ) );
+	}
+	
+	public function extensions_license_cache_notice( $tab, $active_section ) {
+		if ( 'upgrade' === $tab && WPO_WCPDF()->settings->upgrade->get_extensions_license_data() ) {
+			$message = sprintf(
+				/* translators: 1. open anchor tag, 2. close anchor tag */
+				__( 'Kindly be aware that the extension\'s license data is currently stored in cache, impeding the instant update of the information displayed below. To access the latest details, we recommend clearing the cache %1$shere%2$s.', 'woocommerce-pdf-invoices-packing-slips' ),
+				'<a href="' . esc_url( admin_url( 'admin.php?page=wpo_wcpdf_options_page&tab=debug&section=tools' ) ) . '">',
+				'</a>'
+			);
+			printf( '<div class="notice inline notice-warning"><p>%s</p></div>', $message );
+		}
 	}
 
 	public function extension_overview( $tab, $section ) {

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -31,7 +31,7 @@ class Settings_Upgrade {
 		if ( 'upgrade' === $tab && WPO_WCPDF()->settings->upgrade->get_extensions_license_data() ) {
 			$message = sprintf(
 				/* translators: 1. open anchor tag, 2. close anchor tag */
-				__( 'Kindly be aware that the extension\'s license data is currently stored in cache, impeding the instant update of the information displayed below. To access the latest details, we recommend clearing the cache %1$shere%2$s.', 'woocommerce-pdf-invoices-packing-slips' ),
+				__( 'Kindly be aware that the extensions\' license data is currently stored in cache, impeding the instant update of the information displayed below. To access the latest details, we recommend clearing the cache %1$shere%2$s.', 'woocommerce-pdf-invoices-packing-slips' ),
 				'<a href="' . esc_url( admin_url( 'admin.php?page=wpo_wcpdf_options_page&tab=debug&section=tools' ) ) . '">',
 				'</a>'
 			);

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -253,7 +253,7 @@ class Settings_Upgrade {
 			as_unschedule_action( 'wpo_wcpdf_schedule_extensions_license_cache_clearing' );
 		}
 		
-		as_schedule_single_action( strtotime( "+1 day" ), 'wpo_wcpdf_schedule_extensions_license_cache_clearing' );
+		as_schedule_single_action( strtotime( "+1 week" ), 'wpo_wcpdf_schedule_extensions_license_cache_clearing' );
 		
 		return $license_info;
 	}
@@ -284,6 +284,50 @@ class Settings_Upgrade {
 			case 'live':
 				return $this->get_extension_license_infos( true );
 		}
+	}
+	
+	/**
+	 * Check if are any extensions installed
+	 *
+	 * @return void
+	 */
+	public function are_any_extensions_installed() {
+		$installed = false;
+		
+		foreach ( $this->extensions as $extension ) {
+			if ( $this->extension_is_enabled( $extension ) ) {
+				$installed = true;
+				break;
+			}
+		}
+		
+		return $installed;
+	}
+	
+	/**
+	 * Check if bundle (Pro + Templates) is active
+	 *
+	 * @return void
+	 */
+	public function bundle_is_active() {
+		$extension_license_infos = $this->get_extension_license_infos();
+		$bundle                  = false;
+		
+		if ( ! empty( $extension_license_infos ) ) {
+			$bundle = true;
+			
+			foreach ( $this->extensions as $extension ) {
+				if (
+					( isset( $extension_license_infos[ $extension ]['status'] ) && 'valid' !== $extension_license_infos[ $extension ]['status'] ) ||
+					! isset( $extension_license_infos[ $extension ]['status'] )
+				) {
+					$bundle = false;
+					break;
+				}
+			}
+		}
+		
+		return $bundle;
 	}
 	
 }

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -139,11 +139,12 @@ class Settings_Upgrade {
 	/**
 	 * Get PDF extensions license info
 	 *
+	 * @param  bool  $ignore_cache
 	 * @return array
 	 */
-	public function get_extension_license_infos() {
+	public function get_extension_license_infos( $ignore_cache = false ) {
 		$extensions          = $this->extensions;
-		$license_info        = $this->get_extensions_license_data();
+		$license_info        = ! $ignore_cache ? $this->get_extensions_license_data( 'cached' ) : array();
 		$bundle_upgrade_link = '';
 		$license_status      = 'inactive';
 		
@@ -281,7 +282,7 @@ class Settings_Upgrade {
 			case 'cached':
 				return get_option( 'wpo_wcpdf_extensions_license_cache', array() );
 			case 'live':
-				return $this->get_extension_license_infos();
+				return $this->get_extension_license_infos( true );
 		}
 	}
 	

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -9,6 +9,7 @@ if ( ! class_exists( '\\WPO\\WC\\PDF_Invoices\\Settings\\Settings_Upgrade' ) ) :
 
 class Settings_Upgrade {
 	
+	public           $extensions;
 	protected static $_instance = null;
 		
 	public static function instance() {
@@ -18,8 +19,11 @@ class Settings_Upgrade {
 		return self::$_instance;
 	}
 
-	public function __construct()	{
+	public function __construct() {
+		$this->extensions = array( 'pro', 'templates' );
+		
 		add_action( 'wpo_wcpdf_after_settings_page', array( $this, 'extension_overview' ), 10, 2 );
+		add_action( 'wpo_wcpdf_schedule_extensions_license_cache_clearing', array( $this, 'clear_extensions_license_cache' ) );
 	}
 
 	public function extension_overview( $tab, $section ) {
@@ -122,7 +126,7 @@ class Settings_Upgrade {
 	public function extension_is_enabled( $extension ) {
 		$is_enabled = false;
 		
-		if ( ! empty( $extension ) || ! in_array( $extension, [ 'pro', 'templates' ] ) ) {
+		if ( ! empty( $extension ) || ! in_array( $extension, $this->extensions ) ) {
 			$extension_main_function = "WPO_WCPDF_".ucfirst( $extension );
 			if ( function_exists( $extension_main_function ) ) {
 				$is_enabled = true;
@@ -138,14 +142,18 @@ class Settings_Upgrade {
 	 * @return array
 	 */
 	public function get_extension_license_infos() {
-		$extensions          = [ 'pro', 'templates' ];
-		$license_info        = [];
+		$extensions          = $this->extensions;
+		$license_info        = $this->get_extensions_license_data();
 		$bundle_upgrade_link = '';
 		$license_status      = 'inactive';
 		
+		if ( ! empty( $license_info ) ) {
+			return $license_info;
+		}
+		
 		foreach ( $extensions as $extension ) {
-			$license_info[$extension]   = [];
-			$args                       = [];
+			$license_info[ $extension ] = array();
+			$args                       = array();
 			$request                    = null;
 			$license_key                = '';
 			$sidekick                   = false;
@@ -205,8 +213,9 @@ class Settings_Upgrade {
 					continue;
 				}
 				
-				if ( $updater && is_callable( [ $updater, 'remote_license_actions' ] ) && ! empty( $args ) ) {
+				if ( $updater && is_callable( array( $updater, 'remote_license_actions' ) ) && ! empty( $args ) ) {
 					$request = $updater->remote_license_actions( $args );
+					
 					if ( is_object( $request ) && isset( $request->license ) ) {
 						$license_info[$extension]['status'] = $license_status = $request->license;
 						
@@ -237,7 +246,43 @@ class Settings_Upgrade {
 			}
 		}
 		
+		update_option( 'wpo_wcpdf_extensions_license_cache', $license_info );
+					
+		if ( as_next_scheduled_action( 'wpo_wcpdf_schedule_extensions_license_cache_clearing' ) ) {
+			as_unschedule_action( 'wpo_wcpdf_schedule_extensions_license_cache_clearing' );
+		}
+		
+		as_schedule_single_action( strtotime( "+1 day" ), 'wpo_wcpdf_schedule_extensions_license_cache_clearing' );
+		
 		return $license_info;
+	}
+	
+	/**
+	 * Clear extensions license cache
+	 *
+	 * @return void
+	 */
+	public function clear_extensions_license_cache() {
+		delete_option( 'wpo_wcpdf_extensions_license_cache' );
+	}
+	
+	/**
+	 * Get extensions license data
+	 *
+	 * @param  string $type    can be 'cached' or 'live'
+	 * @return array
+	 */
+	public function get_extensions_license_data( $type = 'cached' ) {
+		if ( ! in_array( $type, array( 'cached', 'live' ) ) ) {
+			return array();
+		}
+		
+		switch ( $type ) {
+			case 'cached':
+				return get_option( 'wpo_wcpdf_extensions_license_cache', array() );
+			case 'live':
+				return $this->get_extension_license_infos();
+		}
 	}
 	
 }

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -289,7 +289,7 @@ class Settings_Upgrade {
 	/**
 	 * Check if are any extensions installed
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function are_any_extensions_installed() {
 		$installed = false;
@@ -307,7 +307,7 @@ class Settings_Upgrade {
 	/**
 	 * Check if bundle (Pro + Templates) is active
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function bundle_is_active() {
 		$extension_license_infos = $this->get_extension_license_infos();

--- a/includes/views/advanced-tools.php
+++ b/includes/views/advanced-tools.php
@@ -141,6 +141,17 @@
 					}
 				?>
 			</form>
+			<?php
+				if ( WPO_WCPDF()->settings->upgrade->get_extensions_license_data() ) {
+					$type    = 'warning';
+					$message = __( 'Licenses data is cached', 'woocommerce-pdf-invoices-packing-slips' );
+				} else {
+					$type    = 'success';
+					$message = __( 'Licenses cache is empty', 'woocommerce-pdf-invoices-packing-slips' );
+				}
+				
+				printf( '<div class="notice inline notice-%s"><p>%s</p></div>', $type, $message );
+			?>
 		</div>
 		<!-- /clear_extensions_license_cache -->
 		<?php do_action( 'wpo_wcpdf_after_debug_tools', $this ); ?>

--- a/includes/views/advanced-tools.php
+++ b/includes/views/advanced-tools.php
@@ -120,40 +120,42 @@
 			</form>
 		</div>
 		<!-- /reset_settings -->
-		<!-- clear_extensions_license_cache -->
-		<div class="tool">
-			<h4><?php _e( 'Clear extensions license caching', 'woocommerce-pdf-invoices-packing-slips' ); ?></h4>
-			<p><?php _e( 'This will clear all extensions license caching. This could be required to update the license status in the Upgrade tab or for new Cloud Storage activations (Professional extension).', 'woocommerce-pdf-invoices-packing-slips' ); ?></p>
-			<form method="post">
-				<?php wp_nonce_field( 'wpo_wcpdf_debug_tools_action', 'security' ); ?>
-				<input type="hidden" name="wpo_wcpdf_debug_clear_extensions_license_cache" value="clear_extensions_license_cache">
-				<input type="submit" name="submit" id="submit" class="button" value="<?php esc_attr_e( 'Clear licenses cache', 'woocommerce-pdf-invoices-packing-slips' ); ?>">
-				<?php
-					if ( ! empty( $_POST ) && isset( $_POST['wpo_wcpdf_debug_clear_extensions_license_cache'] ) && 'clear_extensions_license_cache' === $_POST['wpo_wcpdf_debug_clear_extensions_license_cache'] ) {
-						// check permissions
-						if ( ! check_admin_referer( 'wpo_wcpdf_debug_tools_action', 'security' ) ) {
-							return;
-						}
+		<?php if ( WPO_WCPDF()->settings->upgrade->are_any_extensions_installed() ) : ?>
+			<!-- clear_extensions_license_cache -->
+			<div class="tool">
+				<h4><?php _e( 'Clear extensions license caching', 'woocommerce-pdf-invoices-packing-slips' ); ?></h4>
+				<p><?php _e( 'This will clear all extensions\' license caching. This could be required to update the license status in the Upgrade tab or for new Cloud Storage activations (Professional extension).', 'woocommerce-pdf-invoices-packing-slips' ); ?></p>
+				<form method="post">
+					<?php wp_nonce_field( 'wpo_wcpdf_debug_tools_action', 'security' ); ?>
+					<input type="hidden" name="wpo_wcpdf_debug_clear_extensions_license_cache" value="clear_extensions_license_cache">
+					<input type="submit" name="submit" id="submit" class="button" value="<?php esc_attr_e( 'Clear licenses cache', 'woocommerce-pdf-invoices-packing-slips' ); ?>">
+					<?php
+						if ( ! empty( $_POST ) && isset( $_POST['wpo_wcpdf_debug_clear_extensions_license_cache'] ) && 'clear_extensions_license_cache' === $_POST['wpo_wcpdf_debug_clear_extensions_license_cache'] ) {
+							// check permissions
+							if ( ! check_admin_referer( 'wpo_wcpdf_debug_tools_action', 'security' ) ) {
+								return;
+							}
 
-						WPO_WCPDF()->settings->upgrade->clear_extensions_license_cache();
-						
-						printf( '<div class="notice notice-success"><p>%s</p></div>', esc_html__( 'Extensions license cache cleared successfully!', 'woocommerce-pdf-invoices-packing-slips' ) ); 
+							WPO_WCPDF()->settings->upgrade->clear_extensions_license_cache();
+							
+							printf( '<div class="notice notice-success"><p>%s</p></div>', esc_html__( 'Extensions\' license cache cleared successfully!', 'woocommerce-pdf-invoices-packing-slips' ) ); 
+						}
+					?>
+				</form>
+				<?php
+					if ( WPO_WCPDF()->settings->upgrade->get_extensions_license_data() ) {
+						$type    = 'warning';
+						$message = __( 'Licenses data is cached', 'woocommerce-pdf-invoices-packing-slips' );
+					} else {
+						$type    = 'success';
+						$message = __( 'Licenses cache is empty', 'woocommerce-pdf-invoices-packing-slips' );
 					}
+					
+					printf( '<div class="notice inline notice-%s"><p>%s</p></div>', $type, $message );
 				?>
-			</form>
-			<?php
-				if ( WPO_WCPDF()->settings->upgrade->get_extensions_license_data() ) {
-					$type    = 'warning';
-					$message = __( 'Licenses data is cached', 'woocommerce-pdf-invoices-packing-slips' );
-				} else {
-					$type    = 'success';
-					$message = __( 'Licenses cache is empty', 'woocommerce-pdf-invoices-packing-slips' );
-				}
-				
-				printf( '<div class="notice inline notice-%s"><p>%s</p></div>', $type, $message );
-			?>
-		</div>
-		<!-- /clear_extensions_license_cache -->
+			</div>
+			<!-- /clear_extensions_license_cache -->
+		<?php endif; ?>
 		<?php do_action( 'wpo_wcpdf_after_debug_tools', $this ); ?>
 	</div>
 	<!-- danger_zone (admin access only) -->

--- a/includes/views/advanced-tools.php
+++ b/includes/views/advanced-tools.php
@@ -120,6 +120,29 @@
 			</form>
 		</div>
 		<!-- /reset_settings -->
+		<!-- clear_extensions_license_cache -->
+		<div class="tool">
+			<h4><?php _e( 'Clear extensions license caching', 'woocommerce-pdf-invoices-packing-slips' ); ?></h4>
+			<p><?php _e( 'This will clear all extensions license caching. This could be required to update the license status in the Upgrade tab or for new Cloud Storage activations (Professional extension).', 'woocommerce-pdf-invoices-packing-slips' ); ?></p>
+			<form method="post">
+				<?php wp_nonce_field( 'wpo_wcpdf_debug_tools_action', 'security' ); ?>
+				<input type="hidden" name="wpo_wcpdf_debug_clear_extensions_license_cache" value="clear_extensions_license_cache">
+				<input type="submit" name="submit" id="submit" class="button" value="<?php esc_attr_e( 'Clear licenses cache', 'woocommerce-pdf-invoices-packing-slips' ); ?>">
+				<?php
+					if ( ! empty( $_POST ) && isset( $_POST['wpo_wcpdf_debug_clear_extensions_license_cache'] ) && 'clear_extensions_license_cache' === $_POST['wpo_wcpdf_debug_clear_extensions_license_cache'] ) {
+						// check permissions
+						if ( ! check_admin_referer( 'wpo_wcpdf_debug_tools_action', 'security' ) ) {
+							return;
+						}
+
+						WPO_WCPDF()->settings->upgrade->clear_extensions_license_cache();
+						
+						printf( '<div class="notice notice-success"><p>%s</p></div>', esc_html__( 'Extensions license cache cleared successfully!', 'woocommerce-pdf-invoices-packing-slips' ) ); 
+					}
+				?>
+			</form>
+		</div>
+		<!-- /clear_extensions_license_cache -->
 		<?php do_action( 'wpo_wcpdf_after_debug_tools', $this ); ?>
 	</div>
 	<!-- danger_zone (admin access only) -->

--- a/includes/views/settings-page.php
+++ b/includes/views/settings-page.php
@@ -31,7 +31,6 @@ $review_invitation = sprintf(
 	</h2>
 
 	<?php
-	do_action( 'wpo_wcpdf_before_settings_page', $active_tab, $active_section );
 
 	// save or check option to hide extensions ad
 	if ( isset( $_REQUEST['wpo_wcpdf_hide_extensions_ad'] ) && isset( $_REQUEST['_wpnonce'] ) ) {
@@ -60,6 +59,7 @@ $review_invitation = sprintf(
 	<div id="wpo-wcpdf-preview-wrapper" data-preview-states="<?php echo esc_attr( $preview_states ); ?>" data-preview-state="closed" data-from-preview-state="" data-preview-states-lock="<?php echo esc_attr( $preview_states_lock ); ?>">
 
 		<div class="sidebar">
+			<?php do_action( 'wpo_wcpdf_before_settings_page', $active_tab, $active_section ); ?>
 			<form method="post" action="options.php" id="wpo-wcpdf-settings" class="<?php echo esc_attr( "{$active_tab} {$active_section}" ); ?>">
 				<?php
 					do_action( 'wpo_wcpdf_before_settings', $active_tab, $active_section );


### PR DESCRIPTION
closes #686

This PR hides the Upgrade tab on valid bundle (Pro + Templates valid licenses), and implements a new caching system for the licenses data. This new caching system will replace the current Pro license caching.

New tool to clear the licenses cache:

![Screenshot from 2024-01-09 14-38-38](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/assets/533273/d8288a72-dfb8-4c61-ade2-a77bb270d52a)

Includes also a new notice in the Upgrade tab about the caching:

![Screenshot from 2024-01-10 10-54-56](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/assets/533273/e9f1b5ef-cac5-4c6b-b216-bf41961d5e6d)
