### PR TITLE
Fix the level parameter sent to the log() method

### DIFF
--- a/includes/class-wcpdf-updraft-semaphore.php
+++ b/includes/class-wcpdf-updraft-semaphore.php
@@ -77,7 +77,7 @@ class Updraft_Semaphore_3_0 {
 		$sql = $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name = %s", $this->option_name );
 		
 		if ( 1 === (int) $wpdb->get_var( $sql ) ) {
-			$this->log( 'Lock option ('.$this->option_name.', '.$wpdb->options.') already existed in the database', 'debug ');
+			$this->log( 'Lock option (' . $this->option_name . ', ' . $wpdb->options . ') already existed in the database', 'debug' );
 			return 1;
 		}
 		


### PR DESCRIPTION
When using the renumber tool, I got this error:
```
WC_Logger::log was called incorrectly. <code>WC_Logger::log</code> was called with an invalid level "debug ". Backtrace: do_action('wp_ajax_wpo_wcpdf_danger_zone_tools'), WP_Hook->do_action, WP_Hook->apply_filters, WPO\WC\PDF_Invoices\Settings\Settings_Debug->ajax_process_danger_zone_tools, WPO\WC\PDF_Invoices\Settings\Settings_Debug->renumber_or_delete_document, WPO\WC\PDF_Invoices\Documents\Invoice->init_number, WPO\WC\PDF_Invoices\Updraft_Semaphore_3_0->lock, WPO\WC\PDF_Invoices\Updraft_Semaphore_3_0->ensure_database_initialised, WPO\WC\PDF_Invoices\Updraft_Semaphore_3_0->log, WC_Logger->log, wc_doing_it_wrong. This message was added in version 3.0.
````