### PR TITLE
#125 regular price conversion

### DIFF
--- a/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
+++ b/includes/compatibility/class-wcpdf-compatibility-third-party-plugins.php
@@ -65,9 +65,9 @@ class Third_Party_Plugins {
 		}
 
 		// Currency converter implementation.
-		add_action( 'wpo_wcpdf_process_template_order', array( $this, 'add_convert_to_order_currency_filter' ), 11, 2 );
-		add_action( 'wpo_wcpdf_after_html', array( $this, 'remove_convert_to_order_currency_filter' ), 11, 0 );
-		add_action( 'wpo_wcpdf_after_pdf', array( $this, 'remove_convert_to_order_currency_filter' ), 11, 0 );
+		add_action( 'wpo_wcpdf_process_template_order', array( $this, 'add_convert_price_to_order_currency_filter' ), 11, 2 );
+		add_action( 'wpo_wcpdf_after_html', array( $this, 'remove_convert_price_to_order_currency_filter' ), 11, 0 );
+		add_action( 'wpo_wcpdf_after_pdf', array( $this, 'remove_convert_price_to_order_currency_filter' ), 11, 0 );
 	}
 
 	/**
@@ -317,27 +317,25 @@ class Third_Party_Plugins {
 		}
 	}
 
-	public function add_convert_to_order_currency_filter( $document_type, $order_id ) {
+	public function add_convert_price_to_order_currency_filter( $document_type, $order_id ) {
 		remove_all_filters( 'raw_woocommerce_price', 999 );
 		add_filter( 'raw_woocommerce_price', function( $raw_price ) use ( $order_id ) {
-			return $this->convert_to_order_currency( $raw_price, $order_id );
+			return $this->convert_price_to_order_currency( $raw_price, $order_id );
 		}, 999, 1 );
 	}
 
-	public function remove_convert_to_order_currency_filter() {
+	public function remove_convert_price_to_order_currency_filter() {
 		remove_all_filters( 'raw_woocommerce_price', 999 );
 	}
 
-	public function convert_to_order_currency( $raw_price, $order_id ) {
+	public function convert_price_to_order_currency( $raw_price, $order_id ) {
 		$order = wc_get_order( $order_id );
 		$price = $raw_price;
 
 		// Filter for enabling or disabling conversion to order currency.
-		$should_convert = apply_filters( 'wpo_wcpdf_should_convert_to_order_currency', true );
-
-		if($should_convert) {
+		if( apply_filters( 'wpo_wcpdf_should_convert_price_to_order_currency', '__return_true' ) && $order) {
 			// CURCY - Multi Currency for WooCommerce (https://villatheme.com/) implementation
-			if ( function_exists( 'wmc_get_price' ) && method_exists( $order, 'get_currency' ) && function_exists( 'get_woocommerce_currency' ) && get_woocommerce_currency() != $order->get_currency() ) {
+			if ( function_exists( 'wmc_get_price' ) && method_exists( $order, 'get_currency' ) && function_exists( 'get_woocommerce_currency' ) && get_woocommerce_currency() !== $order->get_currency() ) {
 				$price = wmc_get_price( $raw_price, $order->get_currency() );
 			}
 		}
@@ -349,7 +347,7 @@ class Third_Party_Plugins {
 		 * @param float $raw_price Price before conversion.
 		 * @param int   $order_id  The order id from order that is being processed.
 		 */
-		return apply_filters( 'wpo_wcpdf_convert_to_order_currency', $price, $raw_price, $order_id );
+		return apply_filters( 'wpo_wcpdf_convert_price_to_order_currency', $price, $raw_price, $order_id );
 	}
 }
 


### PR DESCRIPTION
closes https://github.com/wpovernight/woocommerce-pdf-ips-templates/issues/125

I have implemented a function that will check if the order currency is the same as the default currency set in Woo Commerce, and will convert the prices to the order currency if order and default currencies are not the same. The prices will remain the same if:

The order currency and default currency are the same.
The order currency does not exist.
The order currency is not set up in the Woo Commerce Multi Currency settings.
This conversion should only affect the PDF values. The order, product, and order item data should not be touched.

I have tested this with the following multi currency plugin - https://docs.villatheme.com/?item=woocommerce-multi-currency

Reproduction steps:

Add a Curcy WooCommerce Multi Currency plugin.
In the plugin settings, set 2 different currencies, one of them being the default one. Wait till the "Rate + Exchange Fee" is properly set up. It takes time for the plugin to retrieve this data, and if you click "Save" before the rates are set, the rates for all currencies will be 1 and the conversion won't make sense.
Add a new order, and try to create a pdf invoice for it. You will also need to setup that the invoice has the "Regular price" field.
The invoice should have the a regular price the same as the product regular price.
Change the default currency.
The regular price should be converted to the order currency.

The function works only for Curcy WooCommerce Multi Currency plugin, but can be extended to other plugins as well.