### PR TITLE
Fix: disables Order Proposal plugin in versions below 2.0.2 to force update

### DIFF
--- a/includes/class-wcpdf-install.php
+++ b/includes/class-wcpdf-install.php
@@ -532,6 +532,16 @@ class Install {
 			}
 		}
 		
+		// 3.7.8-beta-1: deactivate Proposal plugin if version below 2.0.2 to force update
+		if ( version_compare( $installed_version, '3.7.8-beta-1', '<' ) ) {
+			$installed_version = get_option( 'wpo_order_proposal_version' );
+
+			if ( version_compare( $installed_version, '2.0.2', '<' ) ) {
+				deactivate_plugins( 'woocommerce-order-proposal/woocommerce-order-proposal.php' );
+				set_transient( 'wpo_wcpdf_woocommerce_order_proposal_below_2_0_2_deactivated', 'yes', 7 * DAY_IN_SECONDS );
+			}
+		}
+		
 	}
 
 	/**


### PR DESCRIPTION
Regarding this future implementation: https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/pull/705