### PR TITLE
Tweak: hides the extensions banner temporarily

### DIFF
--- a/includes/views/settings-page.php
+++ b/includes/views/settings-page.php
@@ -46,9 +46,10 @@ $review_invitation = sprintf(
 		$hide_ad = get_option( 'wpo_wcpdf_hide_extensions_ad' );
 	}
 	
-	if ( ! $hide_ad && ! ( class_exists( 'WooCommerce_PDF_IPS_Pro' ) && class_exists( 'WooCommerce_PDF_IPS_Templates' ) && class_exists( 'WooCommerce_Ext_PrintOrders' ) ) ) {
-		include( 'extensions.php' );
-	}
+	// to improve later: https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/issues/677
+	// if ( ! $hide_ad && ! ( class_exists( 'WooCommerce_PDF_IPS_Pro' ) && class_exists( 'WooCommerce_PDF_IPS_Templates' ) && class_exists( 'WooCommerce_Ext_PrintOrders' ) ) ) {
+	// 	include( 'extensions.php' );
+	// }
 	
 	// special temporary promo
 	include( 'promo.php' );


### PR DESCRIPTION
#677

Hides the extensions banner temporarily until we get a better/updated one.

![Screenshot from 2024-02-07 15-50-25](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/assets/533273/16cba04a-1ca9-4df8-8740-2b5c08d5977a)
