### PR TITLE
New: function `wcpdf_error_handling`

### DIFF
--- a/includes/wcpdf-functions.php
+++ b/includes/wcpdf-functions.php
@@ -218,6 +218,7 @@ function wcpdf_ubl_headers( $filename, $size ) {
  * 
  * @param  object $document
  * @param  string $output_format
+ * @param  string $error_handling
  * @return string
  */
 function wcpdf_get_document_file( object $document, string $output_format = 'pdf', $error_handling = 'exception' ): string {

--- a/includes/wcpdf-functions.php
+++ b/includes/wcpdf-functions.php
@@ -359,28 +359,23 @@ function wcpdf_output_error( $message, $level = 'error', $e = null ) {
  * Error handling function
  *
  * @param string $message
- * @param string $error_handling
+ * @param string $handling_type
  * @param bool   $log_error
  * @param string $log_level
  * @return mixed
+ * @throws Exception
  */
-function wcpdf_error_handling( $message, $error_handling = 'exception', $log_error = false, $log_level = 'error' ) {
+function wcpdf_error_handling( string $message, string $handling_type = 'exception', bool $log_error = true, string $log_level = 'error' ) {
 	if ( $log_error ) {
 		wcpdf_log_error( $message, $log_level );
 	}
 	
-	switch ( $error_handling ) {
+	switch ( $handling_type ) {
 		case 'exception':
 			throw new \Exception( $message );
 			break;
 		case 'output':
 			wcpdf_output_error( $message, $log_level );
-			break;
-		case 'return':
-			return $message;
-			break;
-		case 'false':
-			return false;
 			break;
 	}
 	


### PR DESCRIPTION
Based on @brualio suggestion via Slack DM to avoid having a fatal error when calling this function by passing a `$document` value has `false` on `wcpdf_get_document_file`. This way we could determine how the function should handle the errors.