### PR TITLE
Check document settings for the "Disable for free orders" option

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -1017,13 +1017,14 @@ class Main {
 	}
 
 	public function disable_free( $allowed, $document ) {
-		if( ! $document->exists() && ! empty($order = $document->order) ) {
-			if ( ! is_callable( array($order, 'get_total') ) ) {
+		if ( ! $document->exists() && ! empty( $document->order ) ) {
+			if ( ! is_callable( array( $document->order, 'get_total' ) ) ) {
 				return false;
 			}
 			// check order total & setting
-			$order_total = $order->get_total();
+			$order_total      = $document->order->get_total();
 			$invoice_settings = WPO_WCPDF()->settings->get_document_settings( $document->get_type() );
+			
 			if ( $order_total == 0 && isset( $invoice_settings['disable_free'] ) ) {
 				return false;
 			} else {

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -1023,7 +1023,8 @@ class Main {
 			}
 			// check order total & setting
 			$order_total = $order->get_total();
-			if ( $order_total == 0 && $document->get_setting('disable_free') ) {
+			$invoice_settings = WPO_WCPDF()->settings->get_document_settings( $document->get_type() );
+			if ( $order_total == 0 && isset( $invoice_settings['disable_free'] ) ) {
 				return false;
 			} else {
 				return $allowed;


### PR DESCRIPTION
This PR switches the condition for the "Disable for free orders" option to the document settings instead of the historical setting (stored within the order data at the moment of its creation).

Closes: #719