### PR TITLE
Update `get_tax_rate` method to use Woo getters

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -640,12 +640,12 @@ abstract class Order_Document_Methods extends Order_Document {
 	 * @param WC_Order|WC_Order_Refund $order WC_Order
 	 * @param bool $force_calculation force calculation of rates rather than retrieving from db
 	 *
-	 * @return string $tax_rates imploded list of tax rates
+	 * @return string|float $tax_rates imploded list of tax rates
 	 */
-	public function get_tax_rate( object $item, $order, bool $force_calculation = false ): string {
+	public function get_tax_rate( object $item, $order, bool $force_calculation = false ) {
 		$line_tax = is_callable( array( $item, 'get_total_tax' ) ) ? $item->get_total_tax() : 0;
 
-		if ( 0 === $line_tax ) {
+		if ( 0 == $line_tax ) {
 			return '-'; // no need to determine tax rate.
 		}
 

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -637,40 +637,38 @@ abstract class Order_Document_Methods extends Order_Document {
 	 * Get the tax rates/percentages for an item
 	 *
 	 * @param object $item order item
-	 * @param WC_Order|WC_Order_Refund $order WC_Order
+	 * @param WC_Abstract_Order $order WC_Order
 	 * @param bool $force_calculation force calculation of rates rather than retrieving from db
 	 *
-	 * @return string|float $tax_rates imploded list of tax rates
+	 * @return string $tax_rates imploded list of tax rates
 	 */
-	public function get_tax_rate( object $item, $order, bool $force_calculation = false ) {
+	public function get_tax_rate( object $item, object $order, bool $force_calculation = false ): string {
+		if ( apply_filters( 'wpo_wcpdf_calculate_tax_rate', false ) ) {
+			return '';
+		}
+
 		$line_tax = is_callable( array( $item, 'get_total_tax' ) ) ? $item->get_total_tax() : 0;
 
 		if ( 0 == $line_tax ) {
 			return '-'; // no need to determine tax rate.
 		}
 
-		$tax_rates = '';
+		$tax_class  = is_callable( array( $item, 'get_tax_class' ) ) ? $item->get_tax_class() : '';
+		$line_total = is_callable( array( $item, 'get_total' ) ) ? $item->get_total() : 0;
+		$tax        = new \WC_Tax();
+		$rates      = $tax->get_rates( $tax_class );
+		$tax_rates  = array();
 
-		if ( ! apply_filters( 'wpo_wcpdf_calculate_tax_rate', false ) ) {
-			$tax_class  = is_callable( array( $item, 'get_tax_class' ) ) ? $item->get_tax_class() : '';
-			$line_total = is_callable( array( $item, 'get_total' ) ) ? $item->get_total() : 0;
-			$tax        = new \WC_Tax();
-			$rates      = $tax->get_rates( $tax_class );
-			$tax_rates  = array();
-
-			foreach ( $rates as $rate ) {
-				$tax_rates[ $rate['label'] ] = round( $rate['rate'], 2 ) . ' %';
-			}
-
-			if ( empty( $tax_rates ) ) {
-				// one last try: manually calculate
-				$tax_rates[] = $this->calculate_tax_rate( $line_total, $line_tax );
-			}
-
-			$tax_rates = implode( ' ,', $tax_rates );
+		foreach ( $rates as $rate ) {
+			$tax_rates[ $rate['label'] ] = round( $rate['rate'], 2 ) . ' %';
 		}
 
-		return $tax_rates;
+		if ( empty( $tax_rates ) ) {
+			// one last try: manually calculate
+			$tax_rates[] = $this->calculate_tax_rate( $line_total, $line_tax );
+		}
+
+		return implode( ' ,', $tax_rates );
 	}
 
 	public function calculate_tax_rate( $price_ex_tax, $tax ) {

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -644,7 +644,7 @@ abstract class Order_Document_Methods extends Order_Document {
 	 */
 	public function get_tax_rate( object $item, object $order, bool $force_calculation = false ): string {
 		if ( apply_filters( 'wpo_wcpdf_calculate_tax_rate', false ) ) {
-			return '';
+			return '-';
 		}
 
 		$line_tax = is_callable( array( $item, 'get_total_tax' ) ) ? $item->get_total_tax() : 0;


### PR DESCRIPTION
close #716 

The Getters method exists in version `3.0.0`:
https://github.com/woocommerce/woocommerce/blob/3.0.0/includes/class-wc-order-item-coupon.php
https://github.com/woocommerce/woocommerce/blob/3.0.0/includes/class-wc-order-item-fee.php
https://github.com/woocommerce/woocommerce/blob/3.0.0/includes/class-wc-order-item-product.php
https://github.com/woocommerce/woocommerce/blob/3.0.0/includes/class-wc-order-item-shipping.php
https://github.com/woocommerce/woocommerce/blob/3.0.0/includes/class-wc-order-item-tax.php