### PR TITLE
New: bumps WooCommerce min version to 3.3

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -953,23 +953,6 @@ class Admin {
 	}
 
 	/**
-	 * Add actions to menu, legacy method
-	 */
-	public function bulk_actions_js() {
-		if ( $this->is_order_page() ) {
-			?>
-			<script type="text/javascript">
-			jQuery(document).ready(function() {
-				<?php foreach (wcpdf_get_bulk_actions() as $action => $title) { ?>
-				jQuery('<option>').val('<?php echo esc_attr( $action ); ?>').html('<?php echo esc_attr( $title ); ?>').appendTo("select[name='action'], select[name='action2']");
-				<?php }	?>
-			});
-			</script>
-			<?php
-		}
-	}
-
-	/**
 	 * Save invoice number date
 	 */
 	public function save_invoice_number_date( $order_id, $order ) {

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -41,12 +41,8 @@ class Admin {
 
 		add_filter( 'request', array( $this, 'request_query_sort_by_column' ) );
 
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '>=' ) ) {
-			add_filter( 'bulk_actions-edit-shop_order', array( $this, 'bulk_actions' ), 20 );
-			add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this, 'bulk_actions' ), 20 ); // WC 7.1+
-		} else {
-			add_action( 'admin_footer', array( $this, 'bulk_actions_js' ) );
-		}
+		add_filter( 'bulk_actions-edit-shop_order', array( $this, 'bulk_actions' ), 20 );
+		add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this, 'bulk_actions' ), 20 ); // WC 7.1+
 		
 		if ( $this->invoice_number_search_enabled() ) { // prevents slowing down the orders list search
 			add_filter( 'woocommerce_shop_order_search_fields', array( $this, 'search_fields' ) );
@@ -470,16 +466,14 @@ class Admin {
 		}
 
 		// resend order emails
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.2', '>=' ) ) {
-			add_meta_box(
-				'wpo_wcpdf_send_emails',
-				__( 'Send order email', 'woocommerce-pdf-invoices-packing-slips' ),
-				array( $this, 'send_order_email_meta_box' ),
-				$screen_id,
-				'side',
-				'high'
-			);
-		}
+		add_meta_box(
+			'wpo_wcpdf_send_emails',
+			__( 'Send order email', 'woocommerce-pdf-invoices-packing-slips' ),
+			array( $this, 'send_order_email_meta_box' ),
+			$screen_id,
+			'side',
+			'high'
+		);
 
 		// create PDF buttons
 		add_meta_box(

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -373,48 +373,21 @@ abstract class Order_Document_Methods extends Order_Document {
 			return; // prevent order notes from all orders showing when document is not loaded properly
 		}
 
-		if ( function_exists('wc_get_order_notes') ) { // WC3.2+
-			$type = ( $filter == 'private' ) ? 'internal' : $filter;
-			$notes = wc_get_order_notes( array(
-				'order_id' => $order_id,
-				'type'     => $type, // use 'internal' for admin and system notes, empty for all
-			) );
+		$type = ( $filter == 'private' ) ? 'internal' : $filter;
+		$notes = wc_get_order_notes( array(
+			'order_id' => $order_id,
+			'type'     => $type, // use 'internal' for admin and system notes, empty for all
+		) );
 
-			if ( $include_system_notes === false ) {
-				foreach ($notes as $key => $note) {
-					if ( $note->added_by == 'system' ) {
-						unset($notes[$key]);
-					}
+		if ( ! $include_system_notes ) {
+			foreach ( $notes as $key => $note ) {
+				if ( $note->added_by == 'system' ) {
+					unset( $notes[ $key ] );
 				}
-			}
-
-			return $notes;
-		} else {
-
-			$args = array(
-				'post_id' => $order_id,
-				'approve' => 'approve',
-				'type'    => 'order_note',
-			);
-
-			remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-
-			$notes = get_comments( $args );
-
-			add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-
-			if ( $notes ) {
-				foreach( $notes as $key => $note ) {
-					if ( $filter == 'customer' && !get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ) {
-						unset($notes[$key]);
-					}
-					if ( $filter == 'private' && get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ) {
-						unset($notes[$key]);
-					}					
-				}
-				return $notes;
 			}
 		}
+
+		return $notes;
 
 	}
 	public function order_notes( $filter = 'customer', $include_system_notes = true ) {

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -786,11 +786,7 @@ abstract class Order_Document_Methods extends Order_Document {
 	 */
 	public function get_thumbnail ( $product ) {
 		// Get default WooCommerce img tag (url/http)
-		if ( version_compare( WOOCOMMERCE_VERSION, '3.3', '>=' ) ) {
-			$thumbnail_size = 'woocommerce_thumbnail';
-		} else {
-			$thumbnail_size = 'shop_thumbnail';
-		}
+		$thumbnail_size        = 'woocommerce_thumbnail';
 		$size                  = apply_filters( 'wpo_wcpdf_thumbnail_size', $thumbnail_size );
 		$thumbnail_img_tag_url = $product->get_image( $size, array( 'title' => '' ) );
 		

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -929,16 +929,8 @@ abstract class Order_Document_Methods extends Order_Document {
 	 * Return/show the total discount
 	 */
 	public function get_order_discount( $type = 'total', $tax = 'incl' ) {
-		if ( $tax == 'incl' ) {
-			switch ($type) {
-				case 'cart':
-					// Cart Discount - pre-tax discounts. (deprecated in WC2.3)
-					$discount_value = $this->order->get_cart_discount();
-					break;
-				case 'order':
-					// Order Discount - post-tax discounts. (deprecated in WC2.3)
-					$discount_value = $this->order->get_order_discount();
-					break;
+		if ( 'incl' === $tax ) {
+			switch ( $type ) {
 				case 'total':
 					// Total Discount
 					$discount_value = $this->order->get_total_discount( false ); // $ex_tax = false
@@ -953,7 +945,7 @@ abstract class Order_Document_Methods extends Order_Document {
 		}
 
 		$discount = array (
-			'label'		=> __('Discount', 'woocommerce-pdf-invoices-packing-slips' ),
+			'label'		=> __( 'Discount', 'woocommerce-pdf-invoices-packing-slips' ),
 			'value'		=> $this->format_price( $discount_value ),
 			'raw_value'	=> $discount_value,
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ In addition to a number of default settings (including a custom header/logo) and
 
 = Minimum Requirements =
 
-* WooCommerce 3.0 or later
+* WooCommerce 3.3 or later
 * WordPress 4.4 or later
 
 = Automatic installation =

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -23,7 +23,7 @@ class WPO_WCPDF {
 
 	public $version              = '3.8.0-beta-1';
 	public $version_php          = '7.2';
-	public $version_woo          = '3.0';
+	public $version_woo          = '3.3';
 	public $version_wp           = '4.4';
 	public $plugin_basename;
 	public $legacy_addons;

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -9,7 +9,7 @@
  * License:              GPLv2 or later
  * License URI:          https://opensource.org/licenses/gpl-license.php
  * Text Domain:          woocommerce-pdf-invoices-packing-slips
- * WC requires at least: 3.0
+ * WC requires at least: 3.3
  * WC tested up to:      8.5
  */
 


### PR DESCRIPTION
Following the same bump for the next Pro extension release, I think we should also do the same here.