### PR TITLE
HPOS: Add new filter to include invoice number in search queries

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -45,6 +45,7 @@ class Admin {
 		add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this, 'bulk_actions' ), 20 ); // WC 7.1+
 		
 		if ( $this->invoice_number_search_enabled() ) { // prevents slowing down the orders list search
+			add_filter( 'woocommerce_order_table_search_query_meta_keys', array( $this, 'search_fields' ) ); // HPOS specific filter
 			add_filter( 'woocommerce_shop_order_search_fields', array( $this, 'search_fields' ) );
 		}
 


### PR DESCRIPTION
When HPOS is enabled the filter `woocommerce_order_table_search_query_meta_keys` needs to be executed.
The other filter is only relevant when CPT orders are in use.

References:
https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php#L241-L254
https://stackoverflow.com/a/77752011