### PR TITLE
Fix: document date parse function being called on non HPOS stores

### DIFF
--- a/includes/settings/class-wcpdf-settings-debug.php
+++ b/includes/settings/class-wcpdf-settings-debug.php
@@ -544,7 +544,7 @@ class Settings_Debug {
 		
 		$args[ $date_arg ] = $from_date . '...' . $to_date;
 		
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '6.8.0', '>=' ) ) {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '6.8.0', '>=' ) && WPO_WCPDF()->order_util->custom_orders_table_usage_is_enabled() ) { // Woo >= 6.8.0 + HPOS
 			$args = wpo_wcpdf_parse_document_date_for_wp_query( $args, $args );
 		} else {
 			add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', 'wpo_wcpdf_parse_document_date_for_wp_query', 10, 2 );


### PR DESCRIPTION
This PR addresses an issue spotted on the Professional extension, which lead to issues in the Bulk Export when using the Document date.

The `meta_query` key used by `wc_get_orders`, and built by our function `wpo_wcpdf_parse_document_date_for_wp_query`, is only available on HPOS.