### PR TITLE
Add  `<p>` tag to allowed tag of the `wpo_wcpdf_sanitize_html_content()` method

### DIFF
--- a/includes/wcpdf-functions.php
+++ b/includes/wcpdf-functions.php
@@ -519,6 +519,7 @@ function wpo_wcpdf_sanitize_html_content( string $html, string $context = '', ar
 		'br'     => array(),
 		'em'     => array(),
 		'strong' => array(),
+		'p'      => array(),
 	), $context ), $allow_tags );
 
 	$safe_tags = array(


### PR DESCRIPTION
The `<p>` tag is necessary to display order notes correctly, and it's safe to add this to the default allowed tags.