### PR TITLE
Fix: the function `get_extensions_license_data` returning empty if no cached data found

### DIFF
--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -283,10 +283,10 @@ class Settings_Upgrade {
 	/**
 	 * Get extensions license data
 	 *
-	 * @param  string $type can be 'cached' or 'live'
+	 * @param string $type can be 'cached' or 'live'
 	 * @return array
 	 */
-	public function get_extensions_license_data( $type = 'cached' ) {
+	public function get_extensions_license_data( string $type = 'cached' ): array {
 		$option_key = 'wpo_wcpdf_extensions_license_cache';
 
 		// default to fetching cached data

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -287,10 +287,6 @@ class Settings_Upgrade {
 	 * @return array
 	 */
 	public function get_extensions_license_data( $type = 'cached' ) {
-		if ( ! in_array( $type, array( 'cached', 'live' ) ) ) {
-			return array();
-		}
-
 		switch ( $type ) {
 			case 'cached':
 				$cached_data = get_option( 'wpo_wcpdf_extensions_license_cache', array() );

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -283,7 +283,7 @@ class Settings_Upgrade {
 	/**
 	 * Get extensions license data
 	 *
-	 * @param  string $type    can be 'cached' or 'live'
+	 * @param  string $type can be 'cached' or 'live'
 	 * @return array
 	 */
 	public function get_extensions_license_data( $type = 'cached' ) {
@@ -296,7 +296,7 @@ class Settings_Upgrade {
 		if ( 'live' === $type || empty( $data ) ) {
 			$data = $this->get_extension_license_infos( true );
 
-			if ( $type === 'cached' ) {
+			if ( 'cached' === $type ) {
 				update_option( $option_key, $data );
 			}
 		}

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -287,19 +287,21 @@ class Settings_Upgrade {
 	 * @return array
 	 */
 	public function get_extensions_license_data( $type = 'cached' ) {
-		switch ( $type ) {
-			case 'cached':
-				$cached_data = get_option( 'wpo_wcpdf_extensions_license_cache', array() );
-				if ( empty( $cached_data ) ) {
-					$cached_data = $this->get_extension_license_infos( true );
-					update_option( 'wpo_wcpdf_extensions_license_cache', $cached_data );
-				}
-				return $cached_data;
-			case 'live':
-				return $this->get_extension_license_infos( true );
-			default:
-				return array();
+		$option_key = 'wpo_wcpdf_extensions_license_cache';
+
+		// default to fetching cached data
+		$data = get_option( $option_key, array() );
+
+		// if type is 'live' or cached data is empty, fetch live data
+		if ( 'live' === $type || empty( $data ) ) {
+			$data = $this->get_extension_license_infos( true );
+
+			if ( $type === 'cached' ) {
+				update_option( $option_key, $data );
+			}
 		}
+
+		return $data;
 	}
 
 	/**

--- a/includes/settings/class-wcpdf-settings-upgrade.php
+++ b/includes/settings/class-wcpdf-settings-upgrade.php
@@ -293,9 +293,16 @@ class Settings_Upgrade {
 
 		switch ( $type ) {
 			case 'cached':
-				return get_option( 'wpo_wcpdf_extensions_license_cache', array() );
+				$cached_data = get_option( 'wpo_wcpdf_extensions_license_cache', array() );
+				if ( empty( $cached_data ) ) {
+					$cached_data = $this->get_extension_license_infos( true );
+					update_option( 'wpo_wcpdf_extensions_license_cache', $cached_data );
+				}
+				return $cached_data;
 			case 'live':
 				return $this->get_extension_license_infos( true );
+			default:
+				return array();
 		}
 	}
 


### PR DESCRIPTION
closes #798