### PR TITLE
New: adds language to PDF HTML

### DIFF
--- a/templates/Simple/html-document-wrapper.php
+++ b/templates/Simple/html-document-wrapper.php
@@ -1,6 +1,6 @@
 <?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
 <!DOCTYPE html>
-<html <?php language_attributes(); ?>>
+<html <?php echo apply_filters( 'wpo_wcpdf_html_language_attributes', get_language_attributes(), $this->get_type(), $this ); ?>>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title><?php $this->title(); ?></title>


### PR DESCRIPTION
This PR adds the HTML language attribute to the PDF, which can help debug language issues in multilingual setups.

![Screenshot from 2024-06-04 09-41-14](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/assets/533273/b3e205f0-0949-4c27-bcc1-ab13d403d03a)
