### PR TITLE
Make totals labels translatable

### DIFF
--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -916,7 +916,8 @@ abstract class Order_Document_Methods extends Order_Document {
 		foreach ( $totals as $key => $total ) {
 			$label = $total['label'];
 			$colon = strrpos( $label, ':' );
-			if ( $colon !== false ) {
+
+			if ( false !== $colon ) {
 				$label = substr_replace( $label, '', $colon, 1 );
 			}
 

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -916,10 +916,10 @@ abstract class Order_Document_Methods extends Order_Document {
 		foreach ( $totals as $key => $total ) {
 			$label = $total['label'];
 			$colon = strrpos( $label, ':' );
-			if( $colon !== false ) {
+			if ( $colon !== false ) {
 				$label = substr_replace( $label, '', $colon, 1 );
 			}
-			$totals[$key]['label'] = $label;
+			$totals[ $key ]['label'] = __( $label, 'woocommerce-pdf-invoices-packing-slips' );
 		}
 
 		// Fix order_total for refunded orders

--- a/includes/documents/abstract-wcpdf-order-document-methods.php
+++ b/includes/documents/abstract-wcpdf-order-document-methods.php
@@ -919,7 +919,16 @@ abstract class Order_Document_Methods extends Order_Document {
 			if ( $colon !== false ) {
 				$label = substr_replace( $label, '', $colon, 1 );
 			}
-			$totals[ $key ]['label'] = __( $label, 'woocommerce-pdf-invoices-packing-slips' );
+
+			$textdomain = 'woocommerce-pdf-invoices-packing-slips';
+
+			if ( ! empty( $label ) ) {
+				if ( function_exists( 'WPO_WCPDF_Pro' ) && isset( \WPO_WCPDF_Pro()->multilingual_full ) && is_callable( array( \WPO_WCPDF_Pro()->multilingual_full, 'maybe_get_string_translation' ) ) ) {
+					$totals[ $key ]['label'] = \WPO_WCPDF_Pro()->multilingual_full->maybe_get_string_translation( $label, $textdomain );
+				} else {
+					$totals[ $key ]['label'] = __( $label, $textdomain );
+				}
+			}
 		}
 
 		// Fix order_total for refunded orders


### PR DESCRIPTION
close #830 

By the fix provided in this PR, the VAT label has been translated:

![image](https://github.com/wpovernight/woocommerce-pdf-invoices-packing-slips/assets/136313810/c1bfa1b3-aca7-4035-825d-fe5832757d01)
