### PR TITLE
Tweak: improved Bulk document `get_html` method

### DIFF
--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -126,15 +126,17 @@ class Bulk_Document {
 			$order    = wc_get_order( $order_id );
 			$document = wcpdf_get_document( $this->get_type(), $order, true );
 
+			if ( ! $document ) {
+				continue;
+			}
+
 			// temporarily apply filters that need to be removed again after the html is generated
 			$html_filters = apply_filters( 'wpo_wcpdf_html_filters', array(), $document );
 			$this->add_filters( $html_filters );
 
 			do_action( 'wpo_wcpdf_before_html', $document->get_type(), $document );
 
-			if ( $document ) {
-				$html_content[ $key ] = $document->get_html( array( 'wrap_html_content' => false ) );
-			}
+			$html_content[ $key ] = $document->get_html( array( 'wrap_html_content' => false ) );
 
 			// remove temporary filters
 			$this->remove_filters( $html_filters );

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -117,7 +117,7 @@ class Bulk_Document {
 	}
 
 	public function get_html() {
-		do_action( 'wpo_wcpdf_before_bulk_html', $this );
+		do_action( 'wpo_wcpdf_before_bulk_document_html', $this );
 
 		$html_content = array();
 		foreach ( $this->order_ids as $key => $order_id ) {
@@ -142,7 +142,7 @@ class Bulk_Document {
 		$this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
 		$html                   = $this->wrapper_document->wrap_html_content( $this->merge_documents( $html_content ) );
 
-		do_action( 'wpo_wcpdf_after_bulk_html', $this );
+		do_action( 'wpo_wcpdf_after_bulk_document_html', $this );
 
 		return $html;
 	}

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -63,7 +63,7 @@ class Bulk_Document {
 		$this->order_ids = $order_ids;
 		$this->is_bulk   = true;
 
-		// output formats (placed after parent construct to override the abstract default)
+		// output formats
 		$this->output_formats = apply_filters( "wpo_wcpdf_{$this->slug}_output_formats", array( 'pdf' ), $this );
 	}
 
@@ -99,14 +99,14 @@ class Bulk_Document {
 		$pdf_filters = apply_filters( 'wpo_wcpdf_pdf_filters', array(), $this );
 		$this->add_filters( $pdf_filters );
 
-		$html = $this->get_html();
+		$html         = $this->get_html();
 		$pdf_settings = array(
 			'paper_size'		=> apply_filters( 'wpo_wcpdf_paper_format', $this->wrapper_document->get_setting( 'paper_size', 'A4' ), $this->get_type(), $this ),
 			'paper_orientation'	=> apply_filters( 'wpo_wcpdf_paper_orientation', 'portrait', $this->get_type(), $this ),
 			'font_subsetting'	=> $this->wrapper_document->get_setting( 'font_subsetting', false ),
 		);
-		$pdf_maker = wcpdf_get_pdf_maker( $html, $pdf_settings, $this );
-		$pdf = apply_filters( 'wpo_wcpdf_pdf_data', $pdf_maker->output(), $this );
+		$pdf_maker    = wcpdf_get_pdf_maker( $html, $pdf_settings, $this );
+		$pdf          = apply_filters( 'wpo_wcpdf_pdf_data', $pdf_maker->output(), $this );
 
 		do_action( 'wpo_wcpdf_after_pdf', $this->get_type(), $this );
 
@@ -150,7 +150,8 @@ class Bulk_Document {
 	public function merge_documents( $html_content ) {
 		// insert page breaks merge
 		$page_break = "\n<div style=\"page-break-before: always;\"></div>\n";
-		$html = implode( $page_break, $html_content );
+		$html       = implode( $page_break, $html_content );
+		
 		return apply_filters( 'wpo_wcpdf_merged_bulk_document_content', $html, $html_content, $this );
 	}
 
@@ -170,11 +171,14 @@ class Bulk_Document {
 		if ( empty( $this->wrapper_document ) ) {
 			$this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
 		}
+		
 		$default_args = array(
 			'order_ids' => $this->order_ids,
 		);
-		$args = $args + $default_args;
+		
+		$args     = $args + $default_args;
 		$filename = $this->wrapper_document->get_filename( $context, $args );
+		
 		return $filename;
 	}
 
@@ -193,11 +197,12 @@ class Bulk_Document {
 	}
 
 	protected function normalize_filter_args( $filter ) {
-		$filter = array_values( $filter );
-		$hook_name = $filter[0];
-		$callback = $filter[1];
-		$priority = isset( $filter[2] ) ? $filter[2] : 10;
+		$filter        = array_values( $filter );
+		$hook_name     = $filter[0];
+		$callback      = $filter[1];
+		$priority      = isset( $filter[2] ) ? $filter[2] : 10;
 		$accepted_args = isset( $filter[3] ) ? $filter[3] : 1;
+		
 		return compact( 'hook_name', 'callback', 'priority', 'accepted_args' );
 	}
 

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -120,6 +120,7 @@ class Bulk_Document {
 		do_action( 'wpo_wcpdf_before_bulk_document_html', $this );
 
 		$html_content = array();
+		
 		foreach ( $this->order_ids as $key => $order_id ) {
 			do_action( 'wpo_wcpdf_process_template_order', $this->get_type(), $order_id );
 

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -123,7 +123,12 @@ class Bulk_Document {
 		foreach ( $this->order_ids as $key => $order_id ) {
 			do_action( 'wpo_wcpdf_process_template_order', $this->get_type(), $order_id );
 
-			$order    = wc_get_order( $order_id );
+			$order = wc_get_order( $order_id );
+			
+			if ( ! $order ) {
+				continue;
+			}
+			
 			$document = wcpdf_get_document( $this->get_type(), $order, true );
 
 			if ( ! $document ) {

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -134,12 +134,8 @@ class Bulk_Document {
 			if ( ! $document ) {
 				continue;
 			}
-
-			do_action( 'wpo_wcpdf_before_html', $document->get_type(), $document );
-
+			
 			$html_content[ $key ] = $document->get_html( array( 'wrap_html_content' => false ) );
-
-			do_action( 'wpo_wcpdf_after_html', $document->get_type(), $document );
 		}
 
 		// get wrapper document & insert body content

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -135,16 +135,9 @@ class Bulk_Document {
 				continue;
 			}
 
-			// temporarily apply filters that need to be removed again after the html is generated
-			$html_filters = apply_filters( 'wpo_wcpdf_html_filters', array(), $document );
-			$this->add_filters( $html_filters );
-
 			do_action( 'wpo_wcpdf_before_html', $document->get_type(), $document );
 
 			$html_content[ $key ] = $document->get_html( array( 'wrap_html_content' => false ) );
-
-			// remove temporary filters
-			$this->remove_filters( $html_filters );
 
 			do_action( 'wpo_wcpdf_after_html', $document->get_type(), $document );
 		}

--- a/includes/documents/class-wcpdf-bulk-document.php
+++ b/includes/documents/class-wcpdf-bulk-document.php
@@ -122,8 +122,6 @@ class Bulk_Document {
 		$html_content = array();
 		
 		foreach ( $this->order_ids as $key => $order_id ) {
-			do_action( 'wpo_wcpdf_process_template_order', $this->get_type(), $order_id );
-
 			$order = wc_get_order( $order_id );
 			
 			if ( ! $order ) {


### PR DESCRIPTION
This PR aims to improve the Bulk document `get_html` method by placing the required hooks inside the orders loop. This is important because we detect and reset languages, in multilingual setups, using this hooks in each document here: https://github.com/wpovernight/woocommerce-pdf-ips-pro/pull/397/files#diff-f5fe2ecddcf1afabc5e611c28a555e0d99f5f1745d4f2dac8af70dda17dadf86R27-R29