### PR TITLE
Apply a filter to modify PDF document data fields

### DIFF
--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -796,7 +796,7 @@ class Admin {
 			return;
 		}
 
-		$data = apply_filters( 'wpo_wcpdf_metabox_data_fields', $data, $document );
+		$data = apply_filters( 'wpo_wcpdf_document_data_meta_box_fields', $data, $document );
 
 		if ( empty( $data ) ) {
 			return;

--- a/includes/class-wcpdf-admin.php
+++ b/includes/class-wcpdf-admin.php
@@ -791,11 +791,19 @@ class Admin {
 		return apply_filters( 'wpo_wcpdf_current_values_for_document', $data, $document );
 	}
 
-	public function output_number_date_edit_fields( $document, $data ) {
-		if ( empty( $document ) || empty( $data ) || empty( $document->order ) || ! is_callable( array( $document->order, 'get_id' ) ) ) {
+	public function output_number_date_edit_fields( $document, $data ): void {
+		if ( empty( $document ) || empty( $document->order ) || ! is_callable( array( $document->order, 'get_id' ) ) ) {
 			return;
 		}
+
+		$data = apply_filters( 'wpo_wcpdf_metabox_data_fields', $data, $document );
+
+		if ( empty( $data ) ) {
+			return;
+		}
+
 		$data = $this->get_current_values_for_document( $document, $data );
+
 		?>
 		<div class="wcpdf-data-fields" data-document="<?= esc_attr( $document->get_type() ); ?>" data-order_id="<?php echo esc_attr( $document->order->get_id() ); ?>">
 			<section class="wcpdf-data-fields-section number-date">


### PR DESCRIPTION
close #844

Sample usage:

Add a note field to the Proforma document:

```php
function wpo_add_notes_to_proforma( $data, $document ): array {
	$data['notes'] = array(
		'label' => __( 'Notes', 'woocommerce-pdf-invoices-packing-slips' ),
	);

	return $data;
}

add_filter( 'wpo_wcpdf_metabox_data_fields', 'wpo_add_notes_to_proforma', 10, 2 );
```

Result:

![image](https://github.com/user-attachments/assets/1f3e4cb4-5c70-47ee-917d-36c102bcfb8c)
