### PR TITLE
Fix: load plugin translations later on `init`

### DIFF
--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -70,7 +70,7 @@ class WPO_WCPDF {
 		require $this->plugin_path() . '/vendor/autoload.php';
 
 		// load the localisation & classes
-		add_action( 'plugins_loaded', array( $this, 'translations' ) );
+		add_action( 'init', array( $this, 'translations' ) );
 		add_action( 'plugins_loaded', array( $this, 'load_classes' ), 9 );
 		add_action( 'in_plugin_update_message-'.$this->plugin_basename, array( $this, 'in_plugin_update_message' ) );
 		add_action( 'before_woocommerce_init', array( $this, 'woocommerce_hpos_compatible' ) );

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -70,8 +70,8 @@ class WPO_WCPDF {
 		require $this->plugin_path() . '/vendor/autoload.php';
 
 		// load the localisation & classes
-		add_action( 'init', array( $this, 'translations' ) );
-		add_action( 'plugins_loaded', array( $this, 'load_classes' ), 9 );
+		add_action( 'init', array( $this, 'translations' ), 8 );
+		add_action( 'init', array( $this, 'load_classes' ), 9 ); // Pro runs on default 10, if this runs after it will not work
 		add_action( 'in_plugin_update_message-'.$this->plugin_basename, array( $this, 'in_plugin_update_message' ) );
 		add_action( 'before_woocommerce_init', array( $this, 'woocommerce_hpos_compatible' ) );
 		add_action( 'admin_notices', array( $this, 'nginx_detected' ) );


### PR DESCRIPTION
closes #870

### Remarks:

- Translations must be loaded before the classes to ensure that all translatable strings are available when needed.
- The classes should be initialized with a lower priority compared to the Pro extension to prevent potential conflicts or issues.