### PR TITLE
Check current user role in the `enable_debug` function

### DIFF
--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -1561,11 +1561,15 @@ class Main {
 	}
 
 	/**
-	 * Enable PHP error output
+	 * Enable PHP error output for administrators.
 	 */
-	public function enable_debug () {
-		error_reporting( E_ALL );
-		ini_set( 'display_errors', 1 );
+	public function enable_debug() {
+		$user = wp_get_current_user();
+
+		if ( $user && in_array( 'administrator', $user->roles, true ) ) {
+			error_reporting( E_ALL );
+			ini_set( 'display_errors', 1 );
+		}
 	}
 
 	public function wc_webhook_topic_hooks( $topic_hooks, $wc_webhook ) {

--- a/includes/class-wcpdf-main.php
+++ b/includes/class-wcpdf-main.php
@@ -1564,9 +1564,7 @@ class Main {
 	 * Enable PHP error output for administrators.
 	 */
 	public function enable_debug() {
-		$user = wp_get_current_user();
-
-		if ( $user && in_array( 'administrator', $user->roles, true ) ) {
+		if ( \WPO_WCPDF()->settings->user_can_manage_settings() ) {
 			error_reporting( E_ALL );
 			ini_set( 'display_errors', 1 );
 		}


### PR DESCRIPTION
Prevent unauthenticated users to enable debug and error reporting.