### PR TITLE
only error out on "header_logo" if both "src" and "path" are empty.

### DIFF
--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1130,12 +1130,11 @@ abstract class OrderDocument {
 			$attachment_src  = wp_get_attachment_image_url( $attachment_id, 'full' );
 			$attachment_path = wp_normalize_path( realpath( get_attached_file( $attachment_id ) ) );
 
-			if ( empty( $attachment_src ) || empty( $attachment_path ) ) {
+			$src = apply_filters( 'wpo_wcpdf_use_path', true ) ? $attachment_path : $attachment_src;
+			if ( empty( $src ) ) {
 				wcpdf_log_error( 'Header logo file not found.', 'critical' );
 				return;
 			}
-
-			$src = apply_filters( 'wpo_wcpdf_use_path', true ) ? $attachment_path : $attachment_src;
 
 			// fix URLs using path
 			if ( ! apply_filters( 'wpo_wcpdf_use_path', true ) && false !== strpos( $src, 'http' ) && false !== strpos( $src, WP_CONTENT_DIR ) ) {


### PR DESCRIPTION
hi

I was debugging an issue where the logo wasn't showing on a site that's using wp-stateless:
https://wordpress.org/plugins/wp-stateless/

I think the `wp_normalize_path` function was failing here, but that shouldn't matter if we only need the URL, so I just moved the check down a few lines and added `\add_filter('wpo_wcpdf_use_path', '__return_false');` to our site, and now it seems to work.

thanks!