### PR TITLE
New: removes space between items table and totals

### DIFF
--- a/templates/Simple/style.css
+++ b/templates/Simple/style.css
@@ -173,7 +173,7 @@ td.order-data table th {
 table.order-details,
 table.notes-totals {
 	width: 100%;
-	margin-bottom: 8mm;
+	margin-bottom: 0;
 	page-break-before: avoid;
 }
 
@@ -258,7 +258,7 @@ table.notes-totals {
 
 table.totals {
 	width: 100%;
-	margin-top: 5mm;
+	margin-top: 0;
 	table-layout: fixed;
 }
 
@@ -267,6 +267,12 @@ table.totals td {
 	border: 0;
 	border-top: 1px solid #ccc;
 	border-bottom: 1px solid #ccc;
+}
+
+table.totals tr:nth-child(1) th,
+table.totals tr:nth-child(1) td {
+	border-top: 0;
+	border-bottom: 0;
 }
 
 table.totals th.description,


### PR DESCRIPTION
closes #905

This PR removes the space between the items table and the totals:

![Screenshot from 2024-11-04 15-05-07](https://github.com/user-attachments/assets/d60e941e-ac46-4d7f-81bc-6c8178f54741)
