### PR TITLE
Tweak: move UBL support out of beta

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -169,13 +169,11 @@ class Settings {
 			),
 		) );
 
-		if ( wcpdf_is_ubl_available() ) {
-			$settings_tabs['ubl'] = array(
-				'title'          => __( 'UBL', 'woocommerce-pdf-invoices-packing-slips' ),
-				'preview_states' => 1,
-				'beta'           => true,
-			);
-		}
+		$settings_tabs['ubl'] = array(
+			'title'          => __( 'Taxes', 'woocommerce-pdf-invoices-packing-slips' ),
+			'preview_states' => 1,
+			//'beta'           => true,
+		);
 
 		// add status and upgrade tabs last in row
 		$settings_tabs['debug'] = array(

--- a/includes/Settings/SettingsDocuments.php
+++ b/includes/Settings/SettingsDocuments.php
@@ -83,9 +83,9 @@ class SettingsDocuments {
 
 								$active    = ( $output_format == $document_output_format ) || ( 'pdf' !== $output_format && ! in_array( $output_format, $section_document->output_formats ) ) ? 'nav-tab-active' : '';
 								$tab_title = strtoupper( esc_html( $document_output_format ) );
-								if ( 'ubl' === $document_output_format ) {
-									$tab_title .= ' <sup class="wcpdf_beta">beta</sup>';
-								}
+								// if ( 'ubl' === $document_output_format ) {
+								// 	$tab_title .= ' <sup class="wcpdf_beta">beta</sup>';
+								// }
 								printf( '<a href="%1$s" class="nav-tab nav-tab-%2$s %3$s">%4$s</a>', esc_url( add_query_arg( 'output_format', $document_output_format ) ), esc_attr( $document_output_format ), $active, $tab_title );
 							}
 						?>

--- a/includes/Settings/SettingsUbl.php
+++ b/includes/Settings/SettingsUbl.php
@@ -59,6 +59,7 @@ class SettingsUbl {
 		switch ( $active_section ) {
 			default:
 			case 'taxes':
+				echo '<p>' . esc_html__( 'To ensure compliance with e-invoicing requirements, please complete the Taxes Classification. This information is essential for accurately generating legally compliant invoices.', 'woocommerce-pdf-invoices-packing-slips' ) . '</p>';
 				$setting = new UblTaxSettings();
 				$setting->output();
 				break;


### PR DESCRIPTION
This PR renames the main plugin settings tab from 'UBL' to 'Taxes' for improved clarity and adds a descriptive text to enhance the user experience on that page.