### PR TITLE
New: add utility function for dynamic string translation

### DIFF
--- a/wpo-ips-functions.php
+++ b/wpo-ips-functions.php
@@ -989,3 +989,20 @@ function wpo_wcpdf_get_simple_template_default_table_headers( $document ): array
 	
 	return apply_filters( 'wpo_wcpdf_simple_template_default_table_headers', $headers, $document );
 }
+
+/**
+ * Dynamic string translation
+ *
+ * @param string $string
+ * @param string $textdomain
+ * @return string
+ */
+function wpo_wcpdf_dynamic_translate( string $string, string $textdomain ): string {
+	if ( ! function_exists( 'translate' ) ) {
+		return $string;
+	}
+	
+    $translation = translate( $string, $textdomain );
+	
+    return $translation !== $string ? $translation : $string; // Fallback to original if not translated
+}


### PR DESCRIPTION
closes #974

This function uses the `translate()` function to retrieve translations for runtime-determined strings, with a fallback to the original string if no translation exists. It ensures compatibility with existing `.po` translations while safely handling cases where the `translate()` function is unavailable.