### PR TITLE
Logo height setting can break document layout

### DIFF
--- a/templates/Simple/style.css
+++ b/templates/Simple/style.css
@@ -114,8 +114,8 @@ table.head {
 
 td.header img {
 	max-height: 3cm; /* may be overridden by the settings */
-	width: auto;
 	max-width: 100%;
+	width: auto;
 }
 
 /* .mpdf td.header img { */

--- a/templates/Simple/style.css
+++ b/templates/Simple/style.css
@@ -115,6 +115,7 @@ table.head {
 td.header img {
 	max-height: 3cm; /* may be overridden by the settings */
 	width: auto;
+	max-width: 100%;
 }
 
 /* .mpdf td.header img { */


### PR DESCRIPTION
closes #976 

**IMPORTANT NOTE - Do the same changes in templates plugin for all templates.**
Done - https://github.com/wpovernight/woocommerce-pdf-ips-templates/issues/364