### PR TITLE
New: add support for multiple handlers under a single root in `UblDocument::get_data()`

### DIFF
--- a/ubl/Documents/UblDocument.php
+++ b/ubl/Documents/UblDocument.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class UblDocument extends Document {
-	
+
 	public function get_root_element() {
 		return apply_filters( 'wpo_wc_ubl_document_root_element', 'Invoice', $this );
 	}
@@ -111,20 +111,24 @@ class UblDocument extends Document {
 
 	public function get_data() {
 		$data = array();
-		
+
 		foreach ( $this->get_format() as $key => $value ) {
 			$options  = isset( $value['options'] ) && is_array( $value['options'] ) ? $value['options'] : array();
 			$handlers = is_array( $value['handler'] ) ? $value['handler'] : array( $value['handler'] );
-			
+
 			// Get the root from options if defined
 			$root_name = isset( $options['root'] ) ? $options['root'] : null;
 			$root_data = array();
-			
+
 			foreach ( $handlers as $handler_class ) {
+				if (  ! class_exists( $handler_class ) ) {
+					continue;
+				}
+
 				$handler   = new $handler_class( $this );
 				$root_data = $handler->handle( $root_data, $options );
 			}
-			
+
 			// Add to $data under the root name if specified, otherwise merge directly
 			if ( $root_name ) {
 				$data[] = array(
@@ -135,8 +139,8 @@ class UblDocument extends Document {
 				$data = array_merge( $data, $root_data );
 			}
 		}
-		
+
 		return apply_filters( 'wpo_wc_ubl_document_data', $data, $this );
 	}
-	
+
 }

--- a/ubl/Documents/UblDocument.php
+++ b/ubl/Documents/UblDocument.php
@@ -111,13 +111,32 @@ class UblDocument extends Document {
 
 	public function get_data() {
 		$data = array();
-
+		
 		foreach ( $this->get_format() as $key => $value ) {
-			$handler = new $value['handler']($this);
-			$options = isset( $value['options'] ) && is_array( $value['options'] ) ? $value['options'] : array();
-			$data    = $handler->handle( $data, $options );
+			$options  = isset( $value['options'] ) && is_array( $value['options'] ) ? $value['options'] : array();
+			$handlers = is_array( $value['handler'] ) ? $value['handler'] : array( $value['handler'] );
+			
+			// Get the root from options if defined
+			$root_name = isset( $options['root'] ) ? $options['root'] : null;
+			$root_data = array();
+			
+			foreach ( $handlers as $handler_class ) {
+				$handler   = new $handler_class( $this );
+				$root_data = $handler->handle( $root_data, $options );
+			}
+			
+			// Add to $data under the root name if specified, otherwise merge directly
+			if ( $root_name ) {
+				$data[] = array(
+					'name'  => $root_name,
+					'value' => $root_data,
+				);
+			} else {
+				$data = array_merge( $data, $root_data );
+			}
 		}
-
+		
 		return apply_filters( 'wpo_wc_ubl_document_data', $data, $this );
 	}
+	
 }


### PR DESCRIPTION
closes #1006

This enhancement is necessary to accommodate country-specific format requirements.