### PR TITLE
Fix: `OrderDocument::get_language_attributes()` return value must be of type string, null returned

### DIFF
--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -461,7 +461,7 @@ abstract class OrderDocument {
 	public function regenerate( $order = null, $data = null ) {
 		$order     = empty( $order ) ? $this->order : $order;
 		$refund_id = false;
-		
+
 		if ( empty( $order ) ) {
 			return;
 		}
@@ -474,18 +474,18 @@ abstract class OrderDocument {
 
 		// save settings
 		$this->save_settings( true );
-		
+
 		// if credit note
 		if ( 'credit-note' === $this->get_type() ) {
 			$refund_id = $order->get_id();
 			$order     = wc_get_order( $order->get_parent_id() );
 		}
-		
+
 		// ubl
 		if ( $this->is_enabled( 'ubl' ) && wcpdf_is_ubl_available() ) {
 			wpo_ips_ubl_save_order_taxes( $order );
 		}
-		
+
 		$note = $refund_id ? sprintf(
 			/* translators: 1. credit note title, 2. refund id */
 			esc_html__( '%1$s (refund #%2$s) was regenerated.', 'woocommerce-pdf-invoices-packing-slips' ),
@@ -496,9 +496,9 @@ abstract class OrderDocument {
 			esc_html__( '%s was regenerated', 'woocommerce-pdf-invoices-packing-slips' ),
 			ucfirst( $this->get_title() )
 		);
-		
+
 		$note = wp_kses( $note, 'strip' );
-		
+
 		// add note to order
 		$order->add_order_note( $note );
 
@@ -977,7 +977,8 @@ abstract class OrderDocument {
 	 */
 	public function get_language_attributes(): string {
 		$language_attributes = apply_filters( 'wpo_wcpdf_document_language_attributes', get_language_attributes(), $this );
-		return apply_filters_deprecated( 'wpo_wcpdf_html_language_attributes', array( $language_attributes, $this->get_type(), $this ), '3.9.1', 'wpo_wcpdf_document_language_attributes' );
+		$language_attributes = apply_filters_deprecated( 'wpo_wcpdf_html_language_attributes', array( $language_attributes, $this->get_type(), $this ), '3.9.1', 'wpo_wcpdf_document_language_attributes' );
+		return $language_attributes ?? '';
 	}
 
 	/**
@@ -1237,7 +1238,7 @@ abstract class OrderDocument {
 			$img_src     = isset( WPO_WCPDF()->settings->debug_settings['embed_images'] ) ? wpo_wcpdf_get_image_src_in_base64( $src ) : $src;
 			$img_element = sprintf( '<img src="%1$s" alt="%2$s"/>', wpo_wcpdf_escape_url_path_or_base64( $img_src ), esc_attr( $company ) );
 			$img_element = apply_filters( 'wpo_wcpdf_header_logo_img_element', $img_element, $attachment_id, $this );
-			
+
 			echo $img_element; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
@@ -1799,7 +1800,7 @@ abstract class OrderDocument {
 		$retired_exists = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			"SHOW TABLES LIKE '" . esc_sql( $retired_table_name ) . "'"
 		) == $retired_table_name;
-		
+
 		if ( $retired_exists ) {
 			$table_removed = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 				"DROP TABLE IF EXISTS `" . esc_sql( $retired_table_name ) . "`" // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
@@ -1815,7 +1816,7 @@ abstract class OrderDocument {
 		$default_exists = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			"SHOW TABLES LIKE '" . esc_sql( $default_table_name ) . "'"
 		) == $default_table_name;
-		
+
 		if ( $default_exists ) {
 			$table_renamed = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 				"ALTER TABLE `" . esc_sql( $default_table_name ) . "` RENAME `" . esc_sql( $retired_table_name ) . "`" // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
@@ -1831,7 +1832,7 @@ abstract class OrderDocument {
 		$current_year_exists = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			"SHOW TABLES LIKE '" . esc_sql( $current_year_table_name ) . "'"
 		) == $current_year_table_name;
-		
+
 		if ( $current_year_exists ) {
 			$table_renamed = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 				"ALTER TABLE `" . esc_sql( $current_year_table_name ) . "` RENAME `" . esc_sql( $default_table_name ) . "`" // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
@@ -1872,7 +1873,7 @@ abstract class OrderDocument {
 		$table_exists = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			"SHOW TABLES LIKE '" . esc_sql( $table_name ) . "'"
 		) == $table_name;
-		
+
 		if ( $table_exists ) {
 			// get year for the last row
 			$year = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery


### PR DESCRIPTION
closes #1054