### PR TITLE
Fix: Product bundle border bottom in PDF template styles

### DIFF
--- a/templates/Simple/style.css
+++ b/templates/Simple/style.css
@@ -183,6 +183,10 @@ table.notes-totals {
 	width: 20%;
 }
 
+.order-details tbody {
+	border-bottom: 1px solid #ccc;
+}
+
 .order-details tr,
 .notes-totals tr {
 	page-break-inside: always;


### PR DESCRIPTION
closes #1049

### Standard product only

![Screenshot from 2025-02-11 11-50-23](https://github.com/user-attachments/assets/3b7fc9c5-28a1-42d6-9627-451b7d229aa3)

### Product Bundle only
![Screenshot from 2025-02-11 11-50-15](https://github.com/user-attachments/assets/f282eeeb-ac4c-4f42-ba82-b0ce9fca89f6)

### Standard and bundle products combined

![Screenshot from 2025-02-11 11-50-32](https://github.com/user-attachments/assets/e9214143-38f4-42b3-8bd1-dc88a6143432)
