### PR TITLE
Clean up special characters in `get_html()` of Bulk Document

### DIFF
--- a/includes/Documents/BulkDocument.php
+++ b/includes/Documents/BulkDocument.php
@@ -138,6 +138,11 @@ class BulkDocument {
 		$this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
 		$html = $this->wrapper_document->wrap_html_content( $this->merge_documents( $html_content ) );
 
+		// clean up special characters
+		if ( apply_filters( 'wpo_wcpdf_convert_encoding', function_exists( 'htmlspecialchars_decode' ) ) ) {
+			$html = htmlspecialchars_decode( wcpdf_convert_encoding( $html ), ENT_QUOTES );
+		}
+
 		do_action( 'wpo_wcpdf_after_html', $this->get_type(), $this );
 
 		// remove temporary filters


### PR DESCRIPTION
close #1062 