### PR TITLE
Tweak: Set PHP file functions as default method in Filesystem class due to WP_Filesystem instability

### DIFF
--- a/includes/Compatibility/FileSystem.php
+++ b/includes/Compatibility/FileSystem.php
@@ -106,24 +106,22 @@ class FileSystem {
 	 * @return void
 	 */
 	public function initialize_wp_filesystem(): void {
+		// Force the use of the direct filesystem method if not already defined
+		if ( ! defined( 'FS_METHOD' ) ) {
+			define( 'FS_METHOD', 'direct' );
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
 		global $wp_filesystem;
 
-		if ( ! WP_Filesystem() || ! $wp_filesystem ) {
-			wcpdf_log_error( 'WP_Filesystem initialization failed. Falling back to PHP methods.', 'warning' );
+		if ( ! WP_Filesystem() || ! $wp_filesystem || ! is_a( $wp_filesystem, '\WP_Filesystem_Direct' ) ) {
+			wcpdf_log_error( 'WP_Filesystem initialization failed or not using direct method. Falling back to PHP methods.', 'warning' );
 			$this->system_enabled = $this->change_setting_value( 'php' );
 			return;
 		}
 
 		$this->wp_filesystem = $wp_filesystem;
-
-		// Ensure the filesystem method is 'direct', otherwise log a warning
-		$filesystem_method = get_filesystem_method();
-		if ( 'direct' !== $filesystem_method ) {
-			wcpdf_log_error( "This plugin only supports the direct filesystem method. Current method: {$filesystem_method}", 'warning' );
-			$this->system_enabled = $this->change_setting_value( 'php' );
-		}
 	}
 	
 	/**

--- a/includes/Compatibility/FileSystem.php
+++ b/includes/Compatibility/FileSystem.php
@@ -37,9 +37,9 @@ class FileSystem {
 	
 	/**
 	 * WP_Filesystem instance.
-	 * @var \WP_Filesystem_Base|null
+	 * @var \WP_Filesystem_Direct|null
 	 */
-	public ?\WP_Filesystem_Base $wp_filesystem = null;
+	public ?\WP_Filesystem_Direct $wp_filesystem = null;
 	
 	/**
 	 * Singleton instance.

--- a/includes/Install.php
+++ b/includes/Install.php
@@ -589,9 +589,19 @@ class Install {
 
 		// 4.3.0-rc.2: reload attachment translations
 		if ( version_compare( $installed_version, '4.3.0-rc.2', '<' ) ) {
-			$debug_settings = get_option( 'wpo_wcpdf_settings_debug', array() );
+			$debug_settings                                   = get_option( 'wpo_wcpdf_settings_debug', array() );
 			$debug_settings['reload_attachment_translations'] = '1';
 			update_option( 'wpo_wcpdf_settings_debug', $debug_settings );
+		}
+		
+		// 4.5.0-beta.2: set default filesystem method to php
+		if ( version_compare( $installed_version, '4.5.0-beta.2', '<' ) ) {
+			$debug_settings = get_option( 'wpo_wcpdf_settings_debug', array() );
+			
+			if ( ! empty( $debug_settings['file_system_method'] ) && 'wp' === $debug_settings['file_system_method'] ) {
+				$debug_settings['file_system_method'] = 'php';
+				update_option( 'wpo_wcpdf_settings_debug', $debug_settings );
+			}
 		}
 		
 		// Maybe reinstall fonts

--- a/includes/Settings/SettingsDebug.php
+++ b/includes/Settings/SettingsDebug.php
@@ -762,15 +762,16 @@ class SettingsDebug {
 				'args'     => array(
 					'option_name' => $option_name,
 					'id'          => 'file_system_method',
-					'default'     => 'wp_filesystem',
+					'default'     => 'php',
 					'options'     => array(
-						'wp'  => __( 'WP Filesystem API (recommended)', 'woocommerce-pdf-invoices-packing-slips' ),
-						'php' => __( 'PHP filesystem functions', 'woocommerce-pdf-invoices-packing-slips' ),
+						'php' => __( 'PHP Filesystem Functions (recommended)', 'woocommerce-pdf-invoices-packing-slips' ),
+						'wp'  => __( 'WP Filesystem API', 'woocommerce-pdf-invoices-packing-slips' ),
 					),
 					'description' => sprintf(
-						/* translators: 1. WP Filesystem, 2. direct */
-						__( 'Choose the filesystem method for file operations. By default, our plugin uses %1$s (only supported in %2$s mode). Select PHP file functions if you encounter issues with %1$s.', 'woocommerce-pdf-invoices-packing-slips' ),
-						'<code>WP Filesystem</code>',
+						/* translators: 1. PHP Filesystem Functions, 2. WP Filesystem API, 3. direct */
+						__( 'Choose the filesystem method for file operations. By default, our plugin uses %1$s. If you prefer to use the %2$s, please note that only the %3$s method is supported.', 'woocommerce-pdf-invoices-packing-slips' ),
+						'<code>' . __( 'PHP Filesystem Functions', 'woocommerce-pdf-invoices-packing-slips' ) . '</code>',
+						'<code>' . __( 'WP Filesystem API', 'woocommerce-pdf-invoices-packing-slips' ) . '</code>',
 						'<code>direct</code>'
 					) . ( has_filter( 'wpo_wcpdf_filesystem_method' ) 
 						? '<div class="notice notice-warning inline"><p><strong>' . __( 'Warning:', 'woocommerce-pdf-invoices-packing-slips' ) . '</strong> ' . __( 'A code snippet is overriding this setting.', 'woocommerce-pdf-invoices-packing-slips' ) . '</p></div>'


### PR DESCRIPTION
closes #1165

This PR also improves the reliability of the WP_Filesystem initialization process.