### PR TITLE
Fix: Fatal error when calling `WC_Tax::get_tax_rate_classes()` on older Woo versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, pdf, ubl, invoices, packing slips
 Requires at least: 4.4
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 4.6.3
+Stable tag: 4.7.0-pr1267.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/ubl/Settings/TaxesSettings.php
+++ b/ubl/Settings/TaxesSettings.php
@@ -47,7 +47,7 @@ class TaxesSettings {
 				$formatted_rates[ $rate->slug ] = ! empty( $rate->name ) ? $rate->name : $rate->slug;
 			}
 			
-		// Older Woocommerce versions
+		// Older Woo versions
 		} else {
 			$slugs = \WC_Tax::get_tax_class_slugs();
 			$names = \WC_Tax::get_tax_classes();

--- a/ubl/Settings/TaxesSettings.php
+++ b/ubl/Settings/TaxesSettings.php
@@ -31,16 +31,35 @@ class TaxesSettings {
 		settings_fields( 'wpo_wcpdf_settings_ubl_taxes' );
 		do_settings_sections( 'wpo_wcpdf_settings_ubl_taxes' );
 
-		$rates                       = \WC_Tax::get_tax_rate_classes();
-		$formatted_rates             = array();
-		$formatted_rates['standard'] = __( 'Standard rate', 'woocommerce-pdf-invoices-packing-slips' );
-
-		foreach ( $rates as $rate ) {
-			if ( empty( $rate->slug ) ) {
-				continue;
+		$formatted_rates = array(
+			'standard' => __( 'Standard rate', 'woocommerce-pdf-invoices-packing-slips' )
+		);
+		
+		// Woo 5.2+
+		if ( is_callable( array( '\WC_Tax', 'get_tax_rate_classes' ) ) ) {
+			$rates = \WC_Tax::get_tax_rate_classes();
+			
+			foreach ( $rates as $rate ) {
+				if ( empty( $rate->slug ) ) {
+					continue;
+				}
+			
+				$formatted_rates[ $rate->slug ] = ! empty( $rate->name ) ? $rate->name : $rate->slug;
 			}
 			
-			$formatted_rates[ $rate->slug ] = ! empty( $rate->name ) ? esc_attr( $rate->name ) : esc_attr( $rate->slug );
+		// Older Woocommerce versions
+		} else {
+			$slugs = \WC_Tax::get_tax_class_slugs();
+			$names = \WC_Tax::get_tax_classes();
+			
+			foreach ( $slugs as $i => $slug ) {
+				if ( empty( $slug ) ) {
+					continue;
+				}
+				
+				$name = ! empty( $names[ $i ] ) ? $names[ $i ] : $slug;
+				$formatted_rates[ $slug ] = $name;
+			}
 		}
 
 		// Dropdown selector for tax classes

--- a/ubl/Settings/TaxesSettings.php
+++ b/ubl/Settings/TaxesSettings.php
@@ -57,7 +57,7 @@ class TaxesSettings {
 					continue;
 				}
 				
-				$name = ! empty( $names[ $i ] ) ? $names[ $i ] : $slug;
+				$name                     = ! empty( $names[ $i ] ) ? $names[ $i ] : $slug;
 				$formatted_rates[ $slug ] = $name;
 			}
 		}

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -4,7 +4,7 @@
  * Requires Plugins:     woocommerce
  * Plugin URI:           https://wpovernight.com/downloads/woocommerce-pdf-invoices-packing-slips-bundle/
  * Description:          Create, print & email PDF or UBL Invoices & PDF Packing Slips for WooCommerce orders.
- * Version:              4.6.3
+ * Version:              4.7.0-pr1267.1
  * Author:               WP Overnight
  * Author URI:           https://www.wpovernight.com
  * License:              GPLv2 or later
@@ -22,7 +22,7 @@ if ( ! class_exists( 'WPO_WCPDF' ) ) :
 
 class WPO_WCPDF {
 
-	public $version              = '4.6.3';
+	public $version              = '4.7.0-pr1267.1';
 	public $version_php          = '7.4';
 	public $version_woo          = '3.3';
 	public $version_wp           = '4.4';


### PR DESCRIPTION
closes #1266