### PR TITLE
New setting to allow choosing default manual invoice number

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -868,9 +868,8 @@ class Admin {
 			$default_number  = 0;
 
 			if (
-				'invoice' === $document->get_type() &&
-				! empty( \WPO_WCPDF()->settings->debug_settings['default_manual_invoice_number'] ) &&
-				'next_invoice_number' === \WPO_WCPDF()->settings->debug_settings['default_manual_invoice_number']
+				! empty( \WPO_WCPDF()->settings->debug_settings['default_manual_document_number'] ) &&
+				'next_document_number' === \WPO_WCPDF()->settings->debug_settings['default_manual_document_number']
 			) {
 				$default_number = $document->get_sequential_number_store()->get_next() ?? 0;
 			}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -865,6 +865,15 @@ class Admin {
 		// Default number data
 		if ( ! isset( $current['number'] ) ) {
 			$number_settings = $document->get_number_settings();
+			$default_number  = 0;
+
+			if (
+				'invoice' === $document->get_type() &&
+				! empty( \WPO_WCPDF()->settings->debug_settings['default_manual_invoice_number'] ) &&
+				'next_invoice_number' === \WPO_WCPDF()->settings->debug_settings['default_manual_invoice_number']
+			) {
+				$default_number = $document->get_sequential_number_store()->get_next() ?? 0;
+			}
 
 			$current['number'] = array(
 				'prefix' => array(
@@ -872,7 +881,7 @@ class Admin {
 					'name'  => "{$name_prefix}number_prefix",
 				),
 				'plain' => array(
-					'value' => 0,
+					'value' => $default_number,
 					'name'  => "{$name_prefix}number_plain",
 				),
 				'suffix' => array(

--- a/includes/Settings/SettingsDebug.php
+++ b/includes/Settings/SettingsDebug.php
@@ -885,19 +885,19 @@ class SettingsDebug {
 			),
 			array(
 				'type'     => 'setting',
-				'id'       => 'default_manual_invoice_number',
-				'title'    => __( 'Default manual invoice number', 'woocommerce-pdf-invoices-packing-slips' ),
+				'id'       => 'default_manual_document_number',
+				'title'    => __( 'Default manual document number', 'woocommerce-pdf-invoices-packing-slips' ),
 				'callback' => 'select',
 				'section'  => 'debug_settings',
 				'args'     => array(
 					'option_name' => $option_name,
-					'id'          => 'default_manual_invoice_number',
+					'id'          => 'default_manual_document_number',
 					'default'     => 'zero',
 					'options'     => array(
-						'zero'                => __( '0 (zero)', 'woocommerce-pdf-invoices-packing-slips' ),
-						'next_invoice_number' => __( 'Next invoice number', 'woocommerce-pdf-invoices-packing-slips' ),
+						'zero'                 => __( '0 (zero)', 'woocommerce-pdf-invoices-packing-slips' ),
+						'next_document_number' => __( 'Next document number', 'woocommerce-pdf-invoices-packing-slips' ),
 					),
-					'description' => __( 'Select the default value for the invoice number field in the "PDF document data" meta box when manually creating a new invoice.', 'woocommerce-pdf-invoices-packing-slips' ),
+					'description' => __( 'Select the default value for the document number field in the "PDF document data" meta box when manually creating a new document.', 'woocommerce-pdf-invoices-packing-slips' ),
 				)
 			),
 			array(

--- a/includes/Settings/SettingsDebug.php
+++ b/includes/Settings/SettingsDebug.php
@@ -885,6 +885,23 @@ class SettingsDebug {
 			),
 			array(
 				'type'     => 'setting',
+				'id'       => 'default_manual_invoice_number',
+				'title'    => __( 'Default manual invoice number', 'woocommerce-pdf-invoices-packing-slips' ),
+				'callback' => 'select',
+				'section'  => 'debug_settings',
+				'args'     => array(
+					'option_name' => $option_name,
+					'id'          => 'default_manual_invoice_number',
+					'default'     => 'zero',
+					'options'     => array(
+						'zero'                => __( '0 (zero)', 'woocommerce-pdf-invoices-packing-slips' ),
+						'next_invoice_number' => __( 'Next invoice number', 'woocommerce-pdf-invoices-packing-slips' ),
+					),
+					'description' => __( 'Select the default value for the invoice number field in the "PDF document data" meta box when manually creating a new invoice.', 'woocommerce-pdf-invoices-packing-slips' ),
+				)
+			),
+			array(
+				'type'     => 'setting',
 				'id'       => 'enable_cleanup',
 				'title'    => __( 'Enable automatic cleanup', 'woocommerce-pdf-invoices-packing-slips' ),
 				'callback' => 'checkbox_text_input',


### PR DESCRIPTION
close #1274

This PR introduces a new setting under the Advanced settings to allow choosing the default invoice number value for the "PDF document data" editing form.

<img width="1015" height="178" alt="image" src="https://github.com/user-attachments/assets/a7db4fe7-a860-4042-bc16-df65939c63d1" />
