### PR TITLE
Fix: Prevent fatal in `yearly_reset_action_missing_notice()` when `$this->settings` is null

### DIFF
--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -484,6 +484,10 @@ class WPO_WCPDF {
 	 * @return void
 	 */
 	public function yearly_reset_action_missing_notice(): void {
+		if ( empty( $this->settings ) || ! method_exists( $this->settings, 'maybe_schedule_yearly_reset_numbers' ) ) {
+			return;
+		}
+	
 		if ( ! $this->settings->maybe_schedule_yearly_reset_numbers() ) {
 			return;
 		}


### PR DESCRIPTION
closes #1298