### PR TITLE
Fix: Remove deprecated `finfo_close()` calls for PHP 8.5 compatibility

### DIFF
--- a/wpo-ips-functions.php
+++ b/wpo-ips-functions.php
@@ -804,7 +804,7 @@ function wpo_wcpdf_get_image_mime_type( string $src ): string {
 		if ( $finfo ) {
 			$mime_type = finfo_file( $finfo, $src );
 			
-			if ( PHP_VERSION_ID < 80000 ) {
+			if ( PHP_VERSION_ID < 80100 ) {
 				finfo_close( $finfo );
 			}
 		}
@@ -847,7 +847,7 @@ function wpo_wcpdf_get_image_mime_type( string $src ): string {
 				if ( $finfo ) {
 					$mime_type = finfo_buffer( $finfo, $image_data );
 					
-					if ( PHP_VERSION_ID < 80000 ) {
+					if ( PHP_VERSION_ID < 80100 ) {
 						finfo_close( $finfo );
 					}
 				}


### PR DESCRIPTION
closes #1303