### PR TITLE
Fix "Include document link in emails" feature bug

### DIFF
--- a/includes/Main.php
+++ b/includes/Main.php
@@ -1907,7 +1907,7 @@ class Main {
 			$is_allowed =
 				in_array( $document->get_type(), $allowed_document_types, true ) &&
 				in_array( $email_id, $selected_emails, true ) &&
-				'woocommerce_email_' . $email_placement === current_filter();
+				( 'woocommerce_email_' . $email_placement ) === current_filter();
 
 			if ( ! apply_filters( 'wpo_wcpdf_add_document_link_to_email_is_allowed', $is_allowed, $order, $sent_to_admin, $plain_text, $email ) ) {
 				continue;


### PR DESCRIPTION
closes #1316

The issue was that the link for each document was being added on any email hook (placement) collectively from all document settings, rather than checking the document's specific placement with the action.

Since only the Invoice document has this feature, we didn't see this bug so far, but a customer reported that since they introduced customer documents to the plugin.