### PR TITLE
Fix: Extended currency symbols show in PDF but not in PDF Preview (#1325)

### DIFF
--- a/includes/Main.php
+++ b/includes/Main.php
@@ -1051,8 +1051,13 @@ class Main {
 	}
 
 	public function html_currency_filters( $filters ) {
-		// only apply these fixes if the bundled dompdf version is used!
-		if ( wcpdf_pdf_maker_is_default() ) {
+		// Apply currency font when Extended currency symbol support is enabled
+		if ( isset( WPO_WCPDF()->settings->general_settings['currency_font'] ) ) {
+			$filters[] = array( 'woocommerce_currency_symbol', array( $this, 'use_currency_font' ), 10001, 2 );
+			// 'wpo_wcpdf_custom_styles' is actually an action, but WP handles them with the same functions
+			$filters[] = array( 'wpo_wcpdf_custom_styles', array( $this, 'currency_symbol_font_styles' ) );
+		} elseif ( wcpdf_pdf_maker_is_default() ) {
+			// only apply these fixes if the bundled dompdf version is used and currency font is not enabled
 			$filters[] = array( 'woocommerce_currency_symbol', array( $this, 'use_currency_code' ), 10001, 2 );
 		}
 		return $filters;


### PR DESCRIPTION
## Summary
Fixes #1325 - Extended currency symbols (like Indian Rupee ₹) now display correctly in HTML preview when 'Extended currency symbol support' is enabled.

## Root Cause
The `html_currency_filters()` method was missing the currency font logic that exists in `pdf_currency_filters()`. When 'Extended currency symbol support' was enabled:
- ✅ **PDFs:** Correctly applied the 'Currencies' font-family to display symbols
- ❌ **HTML Preview:** Did NOT apply this font, causing symbols to display incorrectly or as boxes on systems without native font support

## Changes
- Added currency font wrapping logic to `html_currency_filters()` to match `pdf_currency_filters()` behavior
- When `currency_font` setting is enabled, symbols are now wrapped in `<span class="wcpdf-currency-symbol">` with 'Currencies' font-family
- Made currency font and RTL currency code fallback mutually exclusive using `elseif` to prevent filter conflicts
- Preserved existing RTL currency handling for backward compatibility

## Code Changes
```php
public function html_currency_filters( $filters ) {
    // Apply currency font when Extended currency symbol support is enabled
    if ( isset( WPO_WCPDF()->settings->general_settings['currency_font'] ) ) {
        $filters[] = array( 'woocommerce_currency_symbol', array( $this, 'use_currency_font' ), 10001, 2 );
        $filters[] = array( 'wpo_wcpdf_custom_styles', array( $this, 'currency_symbol_font_styles' ) );
    } elseif ( wcpdf_pdf_maker_is_default() ) {
        // RTL currency code fallback (only when currency font is not enabled)
        $filters[] = array( 'woocommerce_currency_symbol', array( $this, 'use_currency_code' ), 10001, 2 );
    }
    return $filters;
}
```

## Testing
- ✅ HTML preview now wraps currency symbols in `<span class="wcpdf-currency-symbol">`
- ✅ 'Currencies' font-family is applied via `currency_symbol_font_styles()` CSS
- ✅ Indian Rupee (₹) displays correctly in both PDF and HTML preview
- ✅ No conflicts between currency font and RTL currency filters
- ✅ Backward compatible with existing RTL currency handling

## Technical Details
- Both `pdf_currency_filters` and `html_currency_filters` now apply identical logic when `currency_font` setting is enabled
- Priority 10001 ensures currency filters run after WooCommerce's default currency symbol filters
- Uses existing `use_currency_font()` and `currency_symbol_font_styles()` methods (no code duplication)
- Changed second condition to `elseif` to make filters mutually exclusive and prevent conflicts

## Before/After
### Before (currency_font enabled, HTML preview):
```html
<span class="woocommerce-Price-currencySymbol">&#8377;</span>
```
Default font, may show as box (□) on some systems

### After (currency_font enabled, HTML preview):
```html
<span class="woocommerce-Price-currencySymbol"><span class="wcpdf-currency-symbol">&#8377;</span></span>
```
'Currencies' font applied, displays correctly on all systems

## Files Changed
- `includes/Main.php` (7 insertions, 2 deletions)

## Impact
- Minimal, targeted fix
- No breaking changes
- Maintains backward compatibility
- Follows WordPress/WooCommerce coding standards