### PR TITLE
Remove "PDF" prefix from document title in meta box actions

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -625,8 +625,8 @@ class Admin {
 
 				$meta_box_actions[$document->get_type()] = array(
 					'url'                   => esc_url( $document_url ),
-					'alt'                   => "PDF " . $document_title,
-					'title'                 => "PDF " . $document_title,
+					'alt'                   => $document_title,
+					'title'                 => $document_title,
 					'exists'                => $document_exists,
 					'printed'               => $document_printed,
 					'printed_data'          => $document_printed_data,


### PR DESCRIPTION
closes #1509 

Result: 
<img width="341" height="269" alt="image" src="https://github.com/user-attachments/assets/0de7bb21-70e2-4411-85fe-b0fbe994a571" />
