### PR TITLE
Fix: Empty order item prices when WooCommerce subtotal is filtered

### DIFF
--- a/includes/Documents/OrderDocumentMethods.php
+++ b/includes/Documents/OrderDocumentMethods.php
@@ -627,7 +627,7 @@ abstract class OrderDocumentMethods extends OrderDocument {
 				$data['line_subtotal_tax'] = $this->format_price( $item['line_subtotal_tax'] );
 				$data['ex_price']          = $this->get_formatted_item_price( $item, 'total', 'excl' );
 				$data['price']             = $this->get_formatted_item_price( $item, 'total' );
-				$data['order_price']       = $this->order->get_formatted_line_subtotal( $item ); // formatted according to WC settings
+				$data['order_price']       = $this->get_formatted_order_item_price( $item );
 
 				// Calculate the single price with the same rules as the formatted line subtotal (!)
 				// = before discount
@@ -1251,6 +1251,31 @@ abstract class OrderDocumentMethods extends OrderDocument {
 		}
 
 		return $item_price;
+	}
+
+	/**
+	 * Gets the order item price formatted for display.
+	 *
+	 * Uses WooCommerce's formatted line subtotal when available, but falls back to
+	 * our own formatter if a third-party callback empties the WooCommerce value.
+	 *
+	 * @param mixed $item Order item.
+	 * @return string
+	 */
+	public function get_formatted_order_item_price( $item ): string {
+		$order_price = is_callable( array( $this->order, 'get_formatted_line_subtotal' ) )
+			? $this->order->get_formatted_line_subtotal( $item )
+			: '';
+
+		if ( '' !== trim( wp_strip_all_tags( (string) $order_price ) ) ) {
+			return (string) $order_price;
+		}
+
+		return $this->get_formatted_item_price(
+			$item,
+			'total',
+			get_option( 'woocommerce_tax_display_cart', 'excl' )
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, pdf, ubl, invoices, packing slips
 Requires at least: 4.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 5.13.0
+Stable tag: 5.13.1-i1539.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/woocommerce-pdf-invoices-packingslips.php
+++ b/woocommerce-pdf-invoices-packingslips.php
@@ -4,7 +4,7 @@
  * Requires Plugins:     woocommerce
  * Plugin URI:           https://wpovernight.com/downloads/woocommerce-pdf-invoices-packing-slips-bundle/
  * Description:          Create, print & email PDF or Electronic Invoices & PDF Packing Slips for WooCommerce orders.
- * Version:              5.13.0
+ * Version:              5.13.1-i1539.1
  * Author:               WP Overnight
  * Author URI:           https://www.wpovernight.com
  * License:              GPLv2 or later
@@ -22,7 +22,7 @@ if ( ! class_exists( 'WPO_WCPDF' ) ) :
 
 class WPO_WCPDF {
 
-	public $version              = '5.13.0';
+	public $version              = '5.13.1-i1539.1';
 	public $version_php          = '7.4';
 	public $version_woo          = '3.3';
 	public $version_wp           = '4.4';


### PR DESCRIPTION
closes #1539