### PR TITLE
Make cancelled/failed order email labels distinct between admin and customer

### DIFF
--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1849,11 +1849,11 @@ abstract class OrderDocument {
 	*/
 
 	/**
-	 * get all emails registered in WooCommerce
-	 * @param  boolean $remove_defaults switch to remove default woocommerce emails
-	 * @return array   $emails       list of all email ids/slugs and names
+	 * Get all emails registered in WooCommerce
+	 * 
+	 * @return array
 	 */
-	public function get_wc_emails() {
+	public function get_wc_emails(): array {
 		// only run this in the context of the settings page or setup wizard
 		// prevents WPML language mixups
 		$request = stripslashes_deep( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -1863,7 +1863,7 @@ abstract class OrderDocument {
 		}
 
 		// get emails from WooCommerce
-		if (function_exists('WC')) {
+		if ( function_exists( 'WC' ) ) {
 			$mailer = WC()->mailer();
 		} else {
 			global $woocommerce;
@@ -1874,6 +1874,7 @@ abstract class OrderDocument {
 
 			$mailer = $woocommerce->mailer();
 		}
+
 		$wc_emails = $mailer->get_emails();
 
 		$non_order_emails = array(
@@ -1882,24 +1883,26 @@ abstract class OrderDocument {
 		);
 
 		$emails = array();
-		foreach ($wc_emails as $class => $email) {
-			if ( !is_object( $email ) ) {
+
+		foreach ( $wc_emails as $class => $email ) {
+			if ( ! is_object( $email ) ) {
 				continue;
 			}
-			if ( !in_array( $email->id, $non_order_emails ) ) {
-				switch ($email->id) {
+
+			if ( ! in_array( $email->id, $non_order_emails ) ) {
+				switch ( $email->id ) {
 					case 'new_order':
-						$emails[$email->id] = sprintf('%s (%s)', $email->title, __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' ) );
+						$emails[ $email->id ] = sprintf( '%s (%s)', $email->title, __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' ) );
 						break;
 					case 'customer_invoice':
-						$emails[$email->id] = sprintf('%s (%s)', $email->title, __( 'Manual email', 'woocommerce-pdf-invoices-packing-slips' ) );
+						$emails[ $email->id ] = sprintf( '%s (%s)', $email->title, __( 'Manual email', 'woocommerce-pdf-invoices-packing-slips' ) );
 						break;
 					case 'cancelled_order':
 					case 'failed_order':
-						$emails[$email->id] = sprintf('%s (%s)', $email->title, __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' ) );
+						$emails[ $email->id ] = sprintf( '%s (%s)', $email->title, __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' ) );
 						break;
 					default:
-						$emails[$email->id] = $email->title;
+						$emails[ $email->id ] = $email->title;
 						break;
 				}
 			}

--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1881,6 +1881,21 @@ abstract class OrderDocument {
 			'customer_new_account'
 		);
 
+		// first pass: count how many times each title occurs, so we only
+		// disambiguate labels that actually collide (e.g. "Cancelled order"
+		// admin email vs "Cancelled order" customer email)
+		$title_counts = array();
+		foreach ( $wc_emails as $email ) {
+			if ( ! is_object( $email ) ) {
+				continue;
+			}
+			if ( in_array( $email->id, $non_order_emails ) ) {
+				continue;
+			}
+			$title = $email->title;
+			$title_counts[ $title ] = isset( $title_counts[ $title ] ) ? $title_counts[ $title ] + 1 : 1;
+		}
+
 		$emails = array();
 		foreach ($wc_emails as $class => $email) {
 			if ( !is_object( $email ) ) {
@@ -1895,7 +1910,12 @@ abstract class OrderDocument {
 						$emails[$email->id] = sprintf('%s (%s)', $email->title, __( 'Manual email', 'woocommerce-pdf-invoices-packing-slips' ) );
 						break;
 					default:
-						$emails[$email->id] = $email->title;
+						if ( $title_counts[ $email->title ] > 1 ) {
+							$suffix = $email->is_customer_email() ? __( 'Customer email', 'woocommerce-pdf-invoices-packing-slips' ) : __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' );
+							$emails[ $email->id ] = sprintf('%s (%s)', $email->title, $suffix );
+						} else {
+							$emails[ $email->id ] = $email->title;
+						}
 						break;
 				}
 			}

--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1881,18 +1881,6 @@ abstract class OrderDocument {
 			'customer_new_account'
 		);
 
-		$title_counts = array();
-		foreach ( $wc_emails as $email ) {
-			if ( ! is_object( $email ) ) {
-				continue;
-			}
-			if ( in_array( $email->id, $non_order_emails ) ) {
-				continue;
-			}
-			$title = $email->title;
-			$title_counts[ $title ] = isset( $title_counts[ $title ] ) ? $title_counts[ $title ] + 1 : 1;
-		}
-
 		$emails = array();
 		foreach ($wc_emails as $class => $email) {
 			if ( !is_object( $email ) ) {
@@ -1906,13 +1894,12 @@ abstract class OrderDocument {
 					case 'customer_invoice':
 						$emails[$email->id] = sprintf('%s (%s)', $email->title, __( 'Manual email', 'woocommerce-pdf-invoices-packing-slips' ) );
 						break;
+					case 'cancelled_order':
+					case 'failed_order':
+						$emails[$email->id] = sprintf('%s (%s)', $email->title, __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' ) );
+						break;
 					default:
-						if ( $title_counts[ $email->title ] > 1 ) {
-							$suffix = $email->is_customer_email() ? __( 'Customer email', 'woocommerce-pdf-invoices-packing-slips' ) : __( 'Admin email', 'woocommerce-pdf-invoices-packing-slips' );
-							$emails[ $email->id ] = sprintf('%s (%s)', $email->title, $suffix );
-						} else {
-							$emails[ $email->id ] = $email->title;
-						}
+						$emails[$email->id] = $email->title;
 						break;
 				}
 			}

--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1881,9 +1881,6 @@ abstract class OrderDocument {
 			'customer_new_account'
 		);
 
-		// first pass: count how many times each title occurs, so we only
-		// disambiguate labels that actually collide (e.g. "Cancelled order"
-		// admin email vs "Cancelled order" customer email)
 		$title_counts = array();
 		foreach ( $wc_emails as $email ) {
 			if ( ! is_object( $email ) ) {


### PR DESCRIPTION
Closes #1557

Cancelled order and Failed order emails have both admin and customer versions with the same title, so they showed up as duplicate looking checkboxes in the Attach to settings. Added a dynamic check instead of hardcoding these two cases, so any future email title collisions get labeled automatically too.

Only labels that actually collide get the "(Admin email)" / "(Customer email)" suffix now, using `is_customer_email()` to tell them apart.